### PR TITLE
use github repo name as docker image name

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-          name: hobbyfarm/gargantua
+          name: ${{ github.repository }}
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           tag_names: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This change just allows us to build and push test images from a fork.

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
