### PR TITLE
expose log level parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go install -v ./...
 FROM alpine:3.11
 	
 COPY --from=builder /go/bin/gargantua /usr/local/bin/
+ENV LOG_LEVEL "0"
 
 ENTRYPOINT ["gargantua"] 
-CMD ["-v=9", "-logtostderr"] 
+CMD -logtostderr -v=$LOG_LEVEL


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes allow reading the log level from the `LOG_LEVEL` environment variable (with `0` being the default level).

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
