### PR TITLE
seperate dependency download from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 FROM golang:1.13 as builder 
-
 WORKDIR /go/src/github.com/hobbyfarm/gargantua
-COPY go.mod go.sum ./
-RUN go mod download
 
 ENV GOOS=linux 
 ENV CGO_ENABLED=0
 
 COPY . .
-RUN go install -v
+RUN go install -v -mod=vendor
 
 
 FROM alpine:3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM golang:1.13 as builder 
 
 WORKDIR /go/src/github.com/hobbyfarm/gargantua
-COPY . .
+COPY go.mod go.sum ./
+RUN go mod download
 
 ENV GOOS=linux 
 ENV CGO_ENABLED=0
 
-RUN go get -d -v ./...
-RUN go install -v ./...
+COPY . .
+RUN go install -v
 
 
 FROM alpine:3.11


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes allow the docker daemon to cache the vendored modules without re-downloading them every time a file gets changed.

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
