### PR TITLE
log accesscode ids, not full object

### DIFF
--- a/pkg/accesscode/accesscode.go
+++ b/pkg/accesscode/accesscode.go
@@ -144,7 +144,13 @@ func (acc AccessCodeClient) GetClosestAccessCodeForScenario(userID string, scena
 		return iExp.Before(jExp)
 	})
 
-	glog.V(6).Infof("Access code list was %v", accessCodes)
+	if glog.V(6) {
+		var accessCodesList []string
+		for _, ac := range accessCodes {
+			accessCodesList = append(accessCodesList, ac.Spec.Code)
+		}
+		glog.Infof("Access code list was %v", accessCodesList)
+	}
 
 	return accessCodes[0].Name, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This just cleans up the logs a bit by logging only the accesscode names, not the entire accesscode object.

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
