### PR TITLE
Customisation

### DIFF
--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -168,7 +168,7 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 	for _, dynamicBindConfiguration := range dynamicBindConfigurations.Items {
 		environment, err := d.hfClientSet.HobbyfarmV1().Environments().Get(dynamicBindConfiguration.Spec.Environment, metav1.GetOptions{})
 
-		if provisionMethod, ok := environment.Annotations["provisioner"]; ok {
+		if provisionMethod, ok := environment.Annotations["hobbyfarm.io/provisioner"]; ok {
 			if provisionMethod == "external" {
 				provision = false
 			}

--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -2,6 +2,10 @@ package dynamicbindcontroller
 
 import (
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
@@ -13,9 +17,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
-	"math/rand"
-	"strings"
-	"time"
 )
 
 type DynamicBindController struct {
@@ -161,11 +162,17 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 	var chosenDynamicBindConfiguration *hfv1.DynamicBindConfiguration
 	var chosenEnvironment *hfv1.Environment
 	var dbcChosen bool
+	var provision bool
 	dbcChosen = false
-
+	provision = true
 	for _, dynamicBindConfiguration := range dynamicBindConfigurations.Items {
 		environment, err := d.hfClientSet.HobbyfarmV1().Environments().Get(dynamicBindConfiguration.Spec.Environment, metav1.GetOptions{})
 
+		if provisionMethod, ok := environment.Annotations["provisioner"]; ok {
+			if provisionMethod == "external" {
+				provision = false
+			}
+		}
 		if err != nil {
 			glog.Errorf("Error while retrieving environment %v", err)
 			return nil
@@ -279,7 +286,7 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 					KeyPair:                  "",
 					VirtualMachineClaimId:    dynamicBindRequest.Spec.VirtualMachineClaim,
 					UserId:                   vmClaim.Spec.UserId,
-					Provision:                true,
+					Provision:                provision,
 					VirtualMachineSetId:      "",
 				},
 				Status: hfv1.VirtualMachineStatus{

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -212,7 +212,7 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 		env, err := v.envLister.Get(vmset.Spec.Environment)
 		var provision bool
 		provision = true
-		if provisionMethod, ok := env.Annotations["provisioner"]; ok {
+		if provisionMethod, ok := env.Annotations["hobbyfarm.io/provisioner"]; ok {
 			if provisionMethod == "external" {
 				provision = false
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
There two changes in this PR. 
First makes the tfpcontroller optional. This allows us to use the a separate controller to handle the vm provisioning logic.

For example the [hf-ec2-vmcontroller](https://github.com/ibrokethecloud/hf-ec2-vmcontroller) can be used to interface gargantua with [ec2-operator](https://github.com/ibrokethecloud/ec2-operator)

This helps ensure that empty state secrets are not left around in the cluster once the session ends.

This should help with the long term operations of the underlying k8s cluster hobbyfarm is deployed on.

Second: Also cleaned up some http response code messages in the session server to make it easier to troubleshoot issues. 

**Which issue(s) this PR fixes**:
None.
<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
