### PR TITLE
changed go version to a valid version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hobbyfarm/gargantua
 
-go 1.13.4
+go 1.13
 
 replace k8s.io/client-go => k8s.io/client-go v0.15.8
 


### PR DESCRIPTION
Signed-off-by: Eamon Bauman <eamon@eamonbauman.com>

**What this PR does / why we need it**: The `go.mod` version of 1.13.4 is invalid. According to https://golang.org/ref/mod#go-mod-file-go, this should be "a positive integer followed by a dot and a non-negative integer"