### PR TITLE
Allow for configurable SSH username

### DIFF
--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -38,7 +38,7 @@ type VirtualMachineList struct {
 type VirtualMachineSpec struct {
 	Id                       string `json:"id"`
 	VirtualMachineTemplateId string `json:"vm_template_id"`
-	SshUsername				 string `json:"ssh_username"`
+	SshUsername              string `json:"ssh_username"`
 	KeyPair                  string `json:"keypair_name"` // this refers to the secret name for the keypair
 	VirtualMachineClaimId    string `json:"vm_claim_id"`
 	UserId                   string `json:"user"`

--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -38,6 +38,7 @@ type VirtualMachineList struct {
 type VirtualMachineSpec struct {
 	Id                       string `json:"id"`
 	VirtualMachineTemplateId string `json:"vm_template_id"`
+	SshUsername				 string `json:"ssh_username"`
 	KeyPair                  string `json:"keypair_name"` // this refers to the secret name for the keypair
 	VirtualMachineClaimId    string `json:"vm_claim_id"`
 	UserId                   string `json:"user"`

--- a/pkg/apis/hobbyfarm.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hobbyfarm.io/v1/zz_generated.deepcopy.go
@@ -753,6 +753,11 @@ func (in *ScheduledEventSpec) DeepCopyInto(out *ScheduledEventSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Courses != nil {
+		in, out := &in.Courses, &out.Courses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -39,6 +39,7 @@ type VirtualMachineSetController struct {
 
 const (
 	vmEnvironmentIndex = "vm.vmclaim.controllers.hobbyfarm.io/environment-index"
+	defaultUsername = "ubuntu"
 )
 
 func NewVirtualMachineSetController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VirtualMachineSetController, error) {
@@ -225,6 +226,10 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 		glog.V(5).Infof("provisioning %d vms", needed)
 		// this code is so... verbose...
 		for i := 0; i < needed; i++ {
+			sshUser, exists := env.Spec.TemplateMapping[vmt.Name]["ssh_username"]
+			if !exists {
+				sshUser = defaultUsername
+			}
 			vmName := strings.Join([]string{vmset.Spec.BaseName, fmt.Sprintf("%08x", rand.Uint32())}, "-")
 			vm := &hfv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -249,6 +254,7 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 				Spec: hfv1.VirtualMachineSpec{
 					Id:                       vmName,
 					VirtualMachineTemplateId: vmt.Spec.Id,
+					SshUsername: 			  sshUser,
 					KeyPair:                  "",
 					VirtualMachineClaimId:    "",
 					UserId:                   "",

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -39,7 +39,7 @@ type VirtualMachineSetController struct {
 
 const (
 	vmEnvironmentIndex = "vm.vmclaim.controllers.hobbyfarm.io/environment-index"
-	defaultUsername = "ubuntu"
+	defaultSshUsername = "ubuntu"
 )
 
 func NewVirtualMachineSetController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VirtualMachineSetController, error) {
@@ -228,7 +228,7 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 		for i := 0; i < needed; i++ {
 			sshUser, exists := env.Spec.TemplateMapping[vmt.Name]["ssh_username"]
 			if !exists {
-				sshUser = defaultUsername
+				sshUser = defaultSshUsername
 			}
 			vmName := strings.Join([]string{vmset.Spec.BaseName, fmt.Sprintf("%08x", rand.Uint32())}, "-")
 			vm := &hfv1.VirtualMachine{

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -30,6 +30,7 @@ var hfNamespace = "hobbyfarm"
 var sshDev = ""
 var sshDevHost = ""
 var sshDevPort = ""
+var defaultSshUsername = "ubuntu"
 
 func init() {
 	ns := os.Getenv("HF_NAMESPACE")
@@ -116,7 +117,7 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 
 	sshUsername := vm.Spec.SshUsername
 	if len(sshUsername) < 1 {
-		sshUsername = "ubuntu"
+		sshUsername = defaultSshUsername
 	}
 
 	// now use the secret and ssh off to something

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -114,9 +114,14 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sshUsername := vm.Spec.SshUsername
+	if len(sshUsername) < 1 {
+		sshUsername = "ubuntu"
+	}
+
 	// now use the secret and ssh off to something
 	config := &ssh.ClientConfig{
-		User: vm.Spec.SshUsername,
+		User: sshUsername,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -116,7 +116,7 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 
 	// now use the secret and ssh off to something
 	config := &ssh.ClientConfig{
-		User: "ubuntu",
+		User: vm.Spec.SshUsername,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},


### PR DESCRIPTION
Signed-off-by: Eamon Bauman <eamon@eamonbauman.com>

**What this PR does / why we need it**: Currently the ssh username is hardcoded to "ubuntu". This fixes that. 

**Which issue(s) this PR fixes**: fixes https://github.com/hobbyfarm/hobbyfarm/issues/83
