### PR TITLE
Add specific error message for when a user already exists

### DIFF
--- a/pkg/authserver/authserver.go
+++ b/pkg/authserver/authserver.go
@@ -387,7 +387,7 @@ func (a AuthServer) RegisterWithAccessCodeFunc(w http.ResponseWriter, r *http.Re
 		var code = 400
 		if errors.IsAlreadyExists(err) {
 			code = 409
-			msg = "user already exists"
+			msg = err.Error()
 		} else {
 			glog.Errorf("error creating user %s %v", email, err)
 			msg = "error creating user"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,1 @@
+package errors

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,1 +1,28 @@
 package errors
+
+type HobbyfarmError struct {
+	Code int
+	Message string
+	Description string
+}
+
+func (h HobbyfarmError) Error() string {
+	return h.Message
+}
+
+func NewAlreadyExists(msg string) HobbyfarmError {
+	return HobbyfarmError{
+		Code: 409,
+		Message: msg,
+		Description: "resource already exists",
+	}
+}
+
+func IsAlreadyExists(err error) bool {
+	he, ok := err.(HobbyfarmError)
+	if !ok {
+		return false
+	}
+	
+	return he.Code == 409
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Currently, if a user already exists in HobbyFarm, we return a generic "error creating user" message to the caller. This isn't great, as that can mean multiple errors (and does, currently, in Garg code). This PR adds a specific error for when a user already exists. 
