### PR TITLE
changed clientsets to interfaces

### DIFF
--- a/pkg/accesscode/accesscode.go
+++ b/pkg/accesscode/accesscode.go
@@ -11,10 +11,10 @@ import (
 )
 
 type AccessCodeClient struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewAccessCodeClient(hfClientset *hfClientset.Clientset) (*AccessCodeClient, error) {
+func NewAccessCodeClient(hfClientset hfClientset.Interface) (*AccessCodeClient, error) {
 	acc := AccessCodeClient{}
 	acc.hfClientSet = hfClientset
 	return &acc, nil

--- a/pkg/accesscode/accesscode_test.go
+++ b/pkg/accesscode/accesscode_test.go
@@ -1,0 +1,1 @@
+package accesscode

--- a/pkg/accesscode/accesscode_test.go
+++ b/pkg/accesscode/accesscode_test.go
@@ -1,1 +1,0 @@
-package accesscode

--- a/pkg/authclient/authclient.go
+++ b/pkg/authclient/authclient.go
@@ -17,11 +17,11 @@ const (
 )
 
 type AuthClient struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 	userIndexer cache.Indexer
 }
 
-func NewAuthClient(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*AuthClient, error) {
+func NewAuthClient(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*AuthClient, error) {
 	a := AuthClient{}
 	a.hfClientSet = hfClientSet
 	inf := hfInformerFactory.Hobbyfarm().V1().Users().Informer()

--- a/pkg/authserver/authserver.go
+++ b/pkg/authserver/authserver.go
@@ -27,10 +27,10 @@ const (
 
 type AuthServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewAuthServer(authClient *authclient.AuthClient, hfClientSet *hfClientset.Clientset) (AuthServer, error) {
+func NewAuthServer(authClient *authclient.AuthClient, hfClientSet hfClientset.Interface) (AuthServer, error) {
 	a := AuthServer{}
 	a.auth = authClient
 	a.hfClientSet = hfClientSet

--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -20,7 +20,7 @@ import (
 )
 
 type DynamicBindController struct {
-	hfClientSet                 *hfClientset.Clientset
+	hfClientSet                 hfClientset.Interface
 	dynamicBindRequestWorkqueue workqueue.RateLimitingInterface
 
 	dynamicBindRequestLister hfListers.DynamicBindRequestLister
@@ -28,7 +28,7 @@ type DynamicBindController struct {
 	dynamicBindRequestsSynced cache.InformerSynced
 }
 
-func NewDynamicBindController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*DynamicBindController, error) {
+func NewDynamicBindController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*DynamicBindController, error) {
 	dynamicBindController := DynamicBindController{}
 	dynamicBindController.hfClientSet = hfClientSet
 

--- a/pkg/controllers/environment/environment.go
+++ b/pkg/controllers/environment/environment.go
@@ -18,7 +18,7 @@ import (
 )
 
 type EnvironmentController struct {
-	hfClientSet  *hfClientset.Clientset
+	hfClientSet  hfClientset.Interface
 	envWorkqueue workqueue.RateLimitingInterface
 	vmWorkqueue  workqueue.RateLimitingInterface
 	//hfInformerFactory *hfInformers.SharedInformerFactory
@@ -36,7 +36,7 @@ const (
 	vmEnvironmentIndex = "vm.vmclaim.controllers.hobbyfarm.io/environment-index"
 )
 
-func NewEnvironmentController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*EnvironmentController, error) {
+func NewEnvironmentController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*EnvironmentController, error) {
 	envController := EnvironmentController{}
 	envController.hfClientSet = hfClientSet
 	envController.vmSynced = hfInformerFactory.Hobbyfarm().V1().VirtualMachines().Informer().HasSynced

--- a/pkg/controllers/scheduledevent/scheduledeventcontroller.go
+++ b/pkg/controllers/scheduledevent/scheduledeventcontroller.go
@@ -20,7 +20,7 @@ import (
 )
 
 type ScheduledEventController struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 
 	//seWorkqueue workqueue.RateLimitingInterface
 	seWorkqueue workqueue.DelayingInterface
@@ -46,7 +46,7 @@ func init() {
 	}
 }
 
-func NewScheduledEventController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*ScheduledEventController, error) {
+func NewScheduledEventController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*ScheduledEventController, error) {
 	seController := ScheduledEventController{}
 	seController.hfClientSet = hfClientSet
 	seController.seSynced = hfInformerFactory.Hobbyfarm().V1().ScheduledEvents().Informer().HasSynced

--- a/pkg/controllers/session/sessioncontroller.go
+++ b/pkg/controllers/session/sessioncontroller.go
@@ -20,7 +20,7 @@ const (
 )
 
 type SessionController struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 
 	//ssWorkqueue workqueue.RateLimitingInterface
 	ssWorkqueue workqueue.DelayingInterface
@@ -34,7 +34,7 @@ type SessionController struct {
 	ssSynced  cache.InformerSynced
 }
 
-func NewSessionController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*SessionController, error) {
+func NewSessionController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*SessionController, error) {
 	ssController := SessionController{}
 	ssController.hfClientSet = hfClientSet
 	ssController.vmSynced = hfInformerFactory.Hobbyfarm().V1().VirtualMachines().Informer().HasSynced

--- a/pkg/controllers/tfpcontroller/tfpcontroller.go
+++ b/pkg/controllers/tfpcontroller/tfpcontroller.go
@@ -29,14 +29,14 @@ import (
 )
 
 type TerraformProvisionerController struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 	//vmWorkqueue workqueue.RateLimitingInterface
 
 	vmWorkqueue workqueue.Interface
 
-	k8sClientset *k8s.Clientset
+	k8sClientset k8s.Interface
 
-	tfClientset *hfClientset.Clientset
+	tfClientset hfClientset.Interface
 
 	vmLister  hfListers.VirtualMachineLister
 	envLister hfListers.EnvironmentLister
@@ -61,7 +61,7 @@ func init() {
 	}
 }
 
-func NewTerraformProvisionerController(k8sClientSet *k8s.Clientset, hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*TerraformProvisionerController, error) {
+func NewTerraformProvisionerController(k8sClientSet k8s.Interface, hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*TerraformProvisionerController, error) {
 	tfpController := TerraformProvisionerController{}
 	tfpController.hfClientSet = hfClientSet
 

--- a/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
+++ b/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
@@ -25,7 +25,7 @@ const (
 )
 
 type VMClaimController struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 
 	vmLister      hfListers.VirtualMachineLister
 	vmClaimLister hfListers.VirtualMachineClaimLister
@@ -38,7 +38,7 @@ type VMClaimController struct {
 	vmHasSynced      cache.InformerSynced
 }
 
-func NewVMClaimController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VMClaimController, error) {
+func NewVMClaimController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*VMClaimController, error) {
 	vmClaimController := VMClaimController{}
 	vmClaimController.hfClientSet = hfClientSet
 

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -23,7 +23,7 @@ import (
 )
 
 type VirtualMachineSetController struct {
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 	//vmSetWorkqueue workqueue.RateLimitingInterface
 	//vmWorkqueue    workqueue.RateLimitingInterface
 	vmSetWorkqueue   workqueue.Interface
@@ -42,7 +42,7 @@ const (
 	vmEnvironmentIndex = "vm.vmclaim.controllers.hobbyfarm.io/environment-index"
 )
 
-func NewVirtualMachineSetController(hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VirtualMachineSetController, error) {
+func NewVirtualMachineSetController(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*VirtualMachineSetController, error) {
 	vmSetController := VirtualMachineSetController{}
 	vmSetController.hfClientSet = hfClientSet
 

--- a/pkg/courseserver/courseserver.go
+++ b/pkg/courseserver/courseserver.go
@@ -24,7 +24,7 @@ const (
 
 type CourseServer struct {
 	auth          *authclient.AuthClient
-	hfClientSet   *hfClientset.Clientset
+	hfClientSet   hfClientset.Interface
 	acClient      *accesscode.AccessCodeClient
 	courseIndexer cache.Indexer
 }
@@ -34,7 +34,7 @@ type PreparedCourse struct {
 	hfv1.CourseSpec
 }
 
-func NewCourseServer(authClient *authclient.AuthClient, acClient *accesscode.AccessCodeClient, hfClientset *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*CourseServer, error) {
+func NewCourseServer(authClient *authclient.AuthClient, acClient *accesscode.AccessCodeClient, hfClientset hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*CourseServer, error) {
 	course := CourseServer{}
 
 	course.hfClientSet = hfClientset

--- a/pkg/environmentserver/environmentserver.go
+++ b/pkg/environmentserver/environmentserver.go
@@ -21,10 +21,10 @@ import (
 
 type EnvironmentServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewEnvironmentServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset) (*EnvironmentServer, error) {
+func NewEnvironmentServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface) (*EnvironmentServer, error) {
 	es := EnvironmentServer{}
 
 	es.hfClientSet = hfClientset

--- a/pkg/scenarioserver/scenarioserver.go
+++ b/pkg/scenarioserver/scenarioserver.go
@@ -28,7 +28,7 @@ const (
 
 type ScenarioServer struct {
 	auth            *authclient.AuthClient
-	hfClientSet     *hfClientset.Clientset
+	hfClientSet     hfClientset.Interface
 	acClient        *accesscode.AccessCodeClient
 	scenarioIndexer cache.Indexer
 }
@@ -52,7 +52,7 @@ type AdminPreparedScenario struct {
 	hfv1.ScenarioSpec
 }
 
-func NewScenarioServer(authClient *authclient.AuthClient, acClient *accesscode.AccessCodeClient, hfClientset *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*ScenarioServer, error) {
+func NewScenarioServer(authClient *authclient.AuthClient, acClient *accesscode.AccessCodeClient, hfClientset hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*ScenarioServer, error) {
 	scenario := ScenarioServer{}
 
 	scenario.hfClientSet = hfClientset

--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -20,10 +20,10 @@ import (
 
 type ScheduledEventServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewScheduledEventServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset) (*ScheduledEventServer, error) {
+func NewScheduledEventServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface) (*ScheduledEventServer, error) {
 	es := ScheduledEventServer{}
 
 	es.hfClientSet = hfClientset

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -30,7 +30,7 @@ const (
 )
 
 type SessionServer struct {
-	hfClientSet      *hfClientset.Clientset
+	hfClientSet      hfClientset.Interface
 	courseClient     *courseclient.CourseClient
 	scenarioClient   *scenarioclient.ScenarioClient
 	accessCodeClient *accesscode.AccessCodeClient
@@ -38,7 +38,7 @@ type SessionServer struct {
 	ssIndexer        cache.Indexer
 }
 
-func NewSessionServer(authClient *authclient.AuthClient, accessCodeClient *accesscode.AccessCodeClient, scenarioClient *scenarioclient.ScenarioClient, courseClient *courseclient.CourseClient, hfClientSet *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*SessionServer, error) {
+func NewSessionServer(authClient *authclient.AuthClient, accessCodeClient *accesscode.AccessCodeClient, scenarioClient *scenarioclient.ScenarioClient, courseClient *courseclient.CourseClient, hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*SessionServer, error) {
 	a := SessionServer{}
 	a.hfClientSet = hfClientSet
 	a.courseClient = courseClient

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -22,8 +22,8 @@ type ShellProxy struct {
 	auth     *authclient.AuthClient
 	vmClient *vmclient.VirtualMachineClient
 
-	hfClient   *hfClientset.Clientset
-	kubeClient *kubernetes.Clientset
+	hfClient   hfClientset.Interface
+	kubeClient kubernetes.Interface
 }
 
 var hfNamespace = "hobbyfarm"
@@ -42,7 +42,7 @@ func init() {
 	sshDevPort = os.Getenv("SSH_DEV_PORT")
 }
 
-func NewShellProxy(authClient *authclient.AuthClient, vmClient *vmclient.VirtualMachineClient, hfClientSet *hfClientset.Clientset, kubeClient *kubernetes.Clientset) (*ShellProxy, error) {
+func NewShellProxy(authClient *authclient.AuthClient, vmClient *vmclient.VirtualMachineClient, hfClientSet hfClientset.Interface, kubeClient kubernetes.Interface) (*ShellProxy, error) {
 	shellProxy := ShellProxy{}
 
 	shellProxy.auth = authClient

--- a/pkg/userserver/userserver.go
+++ b/pkg/userserver/userserver.go
@@ -18,10 +18,10 @@ import (
 
 type UserServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewUserServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset) (*UserServer, error) {
+func NewUserServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface) (*UserServer, error) {
 	s := UserServer{}
 
 	s.hfClientSet = hfClientset

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -283,7 +283,7 @@ func VerifySession(sLister hfListers.SessionLister, s *hfv1.Session) error {
 
 }
 
-func EnsureVMNotReady(hfClientset *hfClientset.Clientset, vmLister hfListers.VirtualMachineLister, vmName string) error {
+func EnsureVMNotReady(hfClientset hfClientset.Interface, vmLister hfListers.VirtualMachineLister, vmName string) error {
 	//glog.V(5).Infof("ensuring VM %s is not ready", vmName)
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		result, getErr := hfClientset.HobbyfarmV1().VirtualMachines().Get(vmName, metav1.GetOptions{})
@@ -315,7 +315,7 @@ func EnsureVMNotReady(hfClientset *hfClientset.Clientset, vmLister hfListers.Vir
 	return nil
 }
 
-func AvailableRawCapacity(hfClientset *hfClientset.Clientset, capacity hfv1.CMSStruct, virtualMachines []hfv1.VirtualMachine) *hfv1.CMSStruct {
+func AvailableRawCapacity(hfClientset hfClientset.Interface, capacity hfv1.CMSStruct, virtualMachines []hfv1.VirtualMachine) *hfv1.CMSStruct {
 	vmTemplates, err := hfClientset.HobbyfarmV1().VirtualMachineTemplates().List(metav1.ListOptions{})
 	if err != nil {
 		glog.Errorf("unable to list virtual machine templates, got error %v", err)
@@ -342,7 +342,7 @@ func AvailableRawCapacity(hfClientset *hfClientset.Clientset, capacity hfv1.CMSS
 	return &availableCapacity
 }
 
-func MaxVMCountsRaw(hfClientset *hfClientset.Clientset, vmTemplates map[string]int, available hfv1.CMSStruct) int {
+func MaxVMCountsRaw(hfClientset hfClientset.Interface, vmTemplates map[string]int, available hfv1.CMSStruct) int {
 	vmTemplatesFromK8s, err := hfClientset.HobbyfarmV1().VirtualMachineTemplates().List(metav1.ListOptions{})
 	if err != nil {
 		glog.Errorf("unable to list virtual machine templates, got error %v", err)
@@ -382,7 +382,7 @@ type Maximus struct {
 	AvailableCapacity hfv1.CMSStruct    `json:"available_capacity"`
 }
 
-func MaxAvailableDuringPeriod(hfClientset *hfClientset.Clientset, environment string, startString string, endString string) (Maximus, error) {
+func MaxAvailableDuringPeriod(hfClientset hfClientset.Interface, environment string, startString string, endString string) (Maximus, error) {
 
 	duration, _ := time.ParseDuration("30m")
 

--- a/pkg/vmclaimserver/vmclaimserver.go
+++ b/pkg/vmclaimserver/vmclaimserver.go
@@ -20,12 +20,12 @@ const (
 
 type VMClaimServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 
 	vmClaimIndexer cache.Indexer
 }
 
-func NewVMClaimServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VMClaimServer, error) {
+func NewVMClaimServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*VMClaimServer, error) {
 	vmcs := VMClaimServer{}
 
 	vmcs.hfClientSet = hfClientset

--- a/pkg/vmserver/vmserver.go
+++ b/pkg/vmserver/vmserver.go
@@ -20,12 +20,12 @@ const (
 
 type VMServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 
 	vmIndexer cache.Indexer
 }
 
-func NewVMServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset, hfInformerFactory hfInformers.SharedInformerFactory) (*VMServer, error) {
+func NewVMServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory) (*VMServer, error) {
 	vms := VMServer{}
 
 	vms.hfClientSet = hfClientset

--- a/pkg/vmtemplateserver/vmtemplateserver.go
+++ b/pkg/vmtemplateserver/vmtemplateserver.go
@@ -15,10 +15,10 @@ import (
 
 type VirtualMachineTemplateServer struct {
 	auth        *authclient.AuthClient
-	hfClientSet *hfClientset.Clientset
+	hfClientSet hfClientset.Interface
 }
 
-func NewVirtualMachineTemplateServer(authClient *authclient.AuthClient, hfClientset *hfClientset.Clientset) (*VirtualMachineTemplateServer, error) {
+func NewVirtualMachineTemplateServer(authClient *authclient.AuthClient, hfClientset hfClientset.Interface) (*VirtualMachineTemplateServer, error) {
 	as := VirtualMachineTemplateServer{}
 
 	as.hfClientSet = hfClientset


### PR DESCRIPTION
**What this PR does / why we need it**: Changes references to concrete type `Clientset` to `Interface` which allows for usage of fake for testing. 
