### PR TITLE
Minor tweaks to dynamic vm provisioning to avoid spamming the tfpcont…

### DIFF
--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -306,6 +306,12 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 				vm.Spec.SshUsername = sshUser
 			}
 
+			// extra label to indicate external provisioning so tfpcontroller ignores this request //
+			if provisionMethod, ok := chosenEnvironment.Annotations["hobbyfarm.io/provisioner"]; ok {
+				vm.ObjectMeta.Labels["hobbyfarm.io/provisioner"] = provisionMethod
+				vm.Spec.Provision = false
+			}
+
 			if chosenDynamicBindConfiguration.Spec.RestrictedBind {
 				vm.ObjectMeta.Labels["restrictedbind"] = "true"
 				vm.ObjectMeta.Labels["restrictedbindvalue"] = chosenDynamicBindConfiguration.Spec.RestrictedBindValue

--- a/pkg/controllers/tfpcontroller/tfpcontroller.go
+++ b/pkg/controllers/tfpcontroller/tfpcontroller.go
@@ -3,6 +3,13 @@ package tfpcontroller
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
 	tfv1 "github.com/hobbyfarm/gargantua/pkg/apis/terraformcontroller.cattle.io/v1"
@@ -20,12 +27,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
-	"math/rand"
-	"os"
-	"reflect"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type TerraformProvisionerController struct {
@@ -482,6 +483,12 @@ func (t *TerraformProvisionerController) handleProvision(vm *hfv1.VirtualMachine
 
 		}
 	} else {
+		if provisionMethod, ok := vm.ObjectMeta.Labels["hobbyfarm.io/provisioner"]; ok {
+			if provisionMethod == "external" {
+				glog.V(8).Infof("vm %s ignored due to external provisioning label", vm.Name)
+				t.vmWorkqueue.Done(vm.Name)
+			}
+		}
 		glog.V(8).Infof("vm %s was not a provisioned vm", vm.Name)
 	}
 	return nil, false


### PR DESCRIPTION
Passing correct provisioning status for dynamic VM's .

**What this PR does / why we need it**:
The changes in this PR allow the dynamicbindcontroller to look for annotation "hobbyfarm.io/provisioner: external" on the environments and set the provision set to external, along with the passing the annotation as a label to the VM request.

This tfpcontroller has a minor change to ignore the request when vm.Spec.Provision = false and the label is set.

This stops the tfpcontroller from trying to process these requests and spam the log files.

```

E0217 14:39:41.898593   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898601   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898608   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898614   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898621   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898627   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898696   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898705   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898712   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898719   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898726   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898734   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898740   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898747   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898753   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898760   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898766   27896 tfpcontroller.go:162] no executions found for terraform state
E0217 14:39:41.898826   27896 tfpcontroller.go:162] no executions found for terraform state
```

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
