### PR TITLE
On-demand scheduling of VMs

### DIFF
--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -402,6 +402,7 @@ type ScheduledEventSpec struct {
 	Description             string                    `json:"description"`
 	StartTime               string                    `json:"start_time"`
 	EndTime                 string                    `json:"end_time"`
+	OnDemand			    bool					  `json:"on_demand"` // whether or not to provision VMs on-demand
 	RequiredVirtualMachines map[string]map[string]int `json:"required_vms"` // map of environment to a map of strings it should be environment: vm template: count
 	AccessCode              string                    `json:"access_code"`
 	RestrictedBind          bool                      `json:"restricted_bind"` // if restricted_bind is true, we need to make the scenario sessions when they get created only bind to vmsets that are created by this scheduledevent


### PR DESCRIPTION
**What this PR does / why we need it**: Through a new ScheduledEvent flag, `on_demand`, virtual machines can be carved out (of capacity) logically but not pre-provisioned. When combined with a dynamic provisioner such as the built-in terraform or an external provisioner, this allows for on-demand creation of VMs at request time. 

There are two main changes here:
1. Add `on_demand` flag to ScheduledEvent type
2. Configure the ScheduledEventController to:
    a) NOT setup a VirtualMachineSet when `on_demand` is true
    b) Accurately represent burst capacity as the requested VMs from the ScheduledEvent instead of hardcoded burst capacity (e.g. "-1" = 10 dynamic VMs).