### PR TITLE
Edit event

### DIFF
--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -11,6 +11,7 @@ import (
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	hfInformers "github.com/hobbyfarm/gargantua/pkg/client/informers/externalversions"
 	hfListers "github.com/hobbyfarm/gargantua/pkg/client/listers/hobbyfarm.io/v1"
+	"github.com/hobbyfarm/gargantua/pkg/controllers/scheduledevent"
 	"github.com/hobbyfarm/gargantua/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -271,13 +272,14 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 						},
 					},
 					Labels: map[string]string{
-						"dynamic":                  "true",
-						"dynamicbindrequest":       dynamicBindRequest.Name,
-						"dynamicbindconfiguration": chosenDynamicBindConfiguration.Spec.Id,
-						"template":                 vmX.Template,
-						"environment":              chosenDynamicBindConfiguration.Spec.Environment,
-						"bound":                    "true",
-						"ready":                    "false",
+						"dynamic":                          "true",
+						"dynamicbindrequest":               dynamicBindRequest.Name,
+						"dynamicbindconfiguration":         chosenDynamicBindConfiguration.Spec.Id,
+						"template":                         vmX.Template,
+						"environment":                      chosenDynamicBindConfiguration.Spec.Environment,
+						"bound":                            "true",
+						"ready":                            "false",
+						scheduledevent.ScheduledEventLabel: chosenDynamicBindConfiguration.ObjectMeta.Labels[scheduledevent.ScheduledEventLabel],
 					},
 				},
 				Spec: hfv1.VirtualMachineSpec{

--- a/pkg/controllers/session/sessioncontroller.go
+++ b/pkg/controllers/session/sessioncontroller.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/golang/glog"
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	hfInformers "github.com/hobbyfarm/gargantua/pkg/client/informers/externalversions"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
-	"time"
 )
 
 const (
@@ -175,7 +176,7 @@ func (s *SessionController) reconcileSession(ssName string) error {
 
 	if expires.Before(now) && !ss.Status.Finished {
 		// we need to set the session to finished and delete the vm's
-		if ss.Status.Paused && ss.Status.PausedTime != "" {
+		if ss.Status.Active && ss.Status.Paused && ss.Status.PausedTime != "" {
 			pausedExpiration, err := time.Parse(time.UnixDate, ss.Status.PausedTime)
 			if err != nil {
 				glog.Error(err)

--- a/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
+++ b/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
@@ -351,7 +351,7 @@ func (v *VMClaimController) processNextVMClaim() bool {
 								},
 							},
 							Labels: map[string]string{
-								"hobbyfarm.io/session": vmClaim.Name,
+								"hobbyfarm.io/session": vmClaim.Labels["hobbyfarm.io/session"],
 							},
 						},
 						Spec: hfv1.DynamicBindRequestSpec{

--- a/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
+++ b/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
@@ -2,6 +2,10 @@ package vmclaimcontroller
 
 import (
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
@@ -14,9 +18,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
-	"math/rand"
-	"strings"
-	"time"
 )
 
 const (
@@ -348,6 +349,9 @@ func (v *VMClaimController) processNextVMClaim() bool {
 									Name:       vmClaim.Name,
 									UID:        vmClaim.UID,
 								},
+							},
+							Labels: map[string]string{
+								"hobbyfarm.io/session": vmClaim.Name,
 							},
 						},
 						Spec: hfv1.DynamicBindRequestSpec{

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -11,6 +11,7 @@ import (
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	hfInformers "github.com/hobbyfarm/gargantua/pkg/client/informers/externalversions"
 	hfListers "github.com/hobbyfarm/gargantua/pkg/client/listers/hobbyfarm.io/v1"
+	"github.com/hobbyfarm/gargantua/pkg/controllers/scheduledevent"
 	"github.com/hobbyfarm/gargantua/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -246,12 +247,13 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 						},
 					},
 					Labels: map[string]string{
-						"dynamic":     "false",
-						"vmset":       vmset.Name,
-						"template":    vmt.Spec.Id,
-						"environment": env.Name,
-						"bound":       "false",
-						"ready":       "false",
+						"dynamic":                          "false",
+						"vmset":                            vmset.Name,
+						"template":                         vmt.Spec.Id,
+						"environment":                      env.Name,
+						"bound":                            "false",
+						"ready":                            "false",
+						scheduledevent.ScheduledEventLabel: vmset.ObjectMeta.Labels[scheduledevent.ScheduledEventLabel],
 					},
 				},
 				Spec: hfv1.VirtualMachineSpec{

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -28,6 +28,7 @@ const (
 	pauseSSTimeout     = "2h"
 	vmcSessionLabel    = "hobbyfarm.io/session"
 	UserSessionLabel   = "hobbyfarm.io/user"
+	AccessCodeLabel    = "accesscode.hobbyfarm.io"
 )
 
 type SessionServer struct {
@@ -198,7 +199,9 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 	session.Spec.CourseId = course.Spec.Id
 	session.Spec.ScenarioId = scenario.Spec.Id
 	session.Spec.UserId = user.Spec.Id
-
+	labels := make(map[string]string)
+	labels[AccessCodeLabel] = accessCode // map accesscode to session
+	session.Labels = labels
 	var vms []map[string]string
 	if course.Spec.VirtualMachines != nil {
 		vms = course.Spec.VirtualMachines

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -281,7 +281,7 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 func (sss SessionServer) FinishedSessionFunc(w http.ResponseWriter, r *http.Request) {
 	user, err := sss.auth.AuthN(w, r)
 	if err != nil {
-		util.ReturnHTTPMessage(w, r, 403, "forbidden", "no access to create sessions")
+		util.ReturnHTTPMessage(w, r, 403, "forbidden", "no access to finish sessions")
 		return
 	}
 	vars := mux.Vars(r)


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable functionality to edit provisioned (currently running) events. 
Provide a route to delete events.

**Which issue(s) this PR fixes**:
Backend implementation for hobbyfarm/hobbyfarm#75
Fixes hobbyfarm/hobbyfarm#76

