### PR TITLE
Changed shell to lookup an annotation on VM for ssh endpoint info

### DIFF
--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -127,7 +127,7 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the host and port
-	host := vm.Status.PublicIP
+	host := vm.Annotations["sshEndpoint"]
 	port := "22"
 	if sshDev == "true" {
 		if sshDevHost != "" {

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -127,7 +127,10 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the host and port
-	host := vm.Annotations["sshEndpoint"]
+	host, ok := vm.Annotations["sshEndpoint"]
+	if !ok {
+		host = vm.Status.PublicIP
+	}
 	port := "22"
 	if sshDev == "true" {
 		if sshDevHost != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the shell works by trying to establish a ssh connection to the public address of the provisioned instance.
With equinix metal provisioning, the instance can be accessed via serial over ssh console. However this address is not the same as public address of the metal instance. 

This PR allows the hf-shim-controller to put an annotation on the VM object, and this is now used by the shell to setup ssh access to the compute associated with the VM object.

**Which issue(s) this PR fixes**:
None. 

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
