### PR TITLE
Drop requirement for DBRs

### DIFF
--- a/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
+++ b/pkg/controllers/dynamicbindcontroller/dynamicbindcontroller.go
@@ -144,6 +144,7 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 
 	if err != nil {
 		glog.Errorf("error retrieving corresponding virtual machine claim %s for dynamic bind request %s", dynamicBindRequest.Spec.VirtualMachineClaim, dynamicBindRequest.Spec.Id)
+		return err
 	}
 
 	var dbcSelector metav1.ListOptions
@@ -161,6 +162,7 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 
 	if err != nil {
 		glog.Errorf("Error while retrieving dynamic bind configurations, %v", err)
+		return err
 	}
 
 	var chosenDynamicBindConfiguration *hfv1.DynamicBindConfiguration
@@ -179,7 +181,7 @@ func (d *DynamicBindController) reconcileDynamicBindRequest(dynamicBindRequest *
 		}
 		if err != nil {
 			glog.Errorf("Error while retrieving environment %v", err)
-			return nil
+			return err
 		}
 
 		if !environment.Spec.BurstCapable {

--- a/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
+++ b/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
@@ -266,7 +266,7 @@ func (v *VMClaimController) processVMClaim(vmc *hfv1.VirtualMachineClaim) (err e
 				return err
 			}
 		} else {
-			glog.Error("vmc bind mode needs to be either dynamic or static.. ignoring this object %s", vmc.Name)
+			glog.Errorf("vmc bind mode needs to be either dynamic or static.. ignoring this object %s", vmc.Name)
 			return nil
 		}
 
@@ -503,7 +503,7 @@ func (v *VMClaimController) assignNextFreeVM(vmClaimId string, user string, temp
 	}
 
 	vms, err := v.vmLister.List(vmLabels.AsSelector())
-	glog.V(4).Info("found %d vm's matching this requirement", len(vms))
+	glog.V(4).Infof("found %d vm's matching this requirement", len(vms))
 	if err != nil {
 		return "", fmt.Errorf("error while listing all vms %v", err)
 	}

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -196,6 +196,8 @@ func (v *VirtualMachineSetController) processNextVMSet() bool {
 		return true
 	}
 
+	// successfully reconcilled, mark object as done
+	v.vmSetWorkqueue.Done(obj)
 	return true
 }
 

--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -172,8 +172,12 @@ func (v *VirtualMachineSetController) processNextVM() bool {
 		// this should avoid triggering unwanted reconciles of VMClaims until the VM's are running
 		if !vm.DeletionTimestamp.IsZero() {
 			glog.V(4).Infof("requeuing vmset %s to account for tainted vm %s", vm.Spec.VirtualMachineSetId, vm.Name)
+			err = v.removeVMFinalizer(vm)
+			if err != nil {
+				glog.Errorf("error removing vm finalizer on vm %s", vm.Name)
+				return err
+			}
 			defer v.vmSetWorkqueue.Add(vm.Spec.VirtualMachineSetId)
-			return v.removeVMFinalizer(vm)
 		}
 
 		return nil

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -220,6 +220,7 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 		labels := make(map[string]string)
 		labels[vmcSessionLabel] = session.Name  // map vmc to session
 		labels[UserSessionLabel] = user.Spec.Id // map session to user in a way that is searchable
+		labels[AccessCodeLabel] = session.Labels[AccessCodeLabel]
 		virtualMachineClaim.Labels = labels
 		virtualMachineClaim.Spec.Id = vmcId
 		virtualMachineClaim.Name = vmcId

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	ssIndex            = "sss.hobbyfarm.io/session-id-index"
-	newSSTimeout       = "5m"
-	keepaliveSSTimeout = "5m"
-	pauseSSTimeout     = "2h"
-	vmcSessionLabel    = "hobbyfarm.io/session"
-	UserSessionLabel   = "hobbyfarm.io/user"
-	AccessCodeLabel    = "accesscode.hobbyfarm.io"
+	ssIndex             = "sss.hobbyfarm.io/session-id-index"
+	newSSTimeout        = "5m"
+	keepaliveSSTimeout  = "5m"
+	pauseSSTimeout      = "2h"
+	vmcSessionLabel     = "hobbyfarm.io/session"
+	UserSessionLabel    = "hobbyfarm.io/user"
+	AccessCodeLabel     = "accesscode.hobbyfarm.io"
 	ScheduledEventLabel = "hobbyfarm.io/scheduledevent"
 )
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -127,7 +127,7 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the host and port
-	host := vm.Status.PublicIP
+	host := vm.Annotations["sshEndpoint"]
 	port := "22"
 	if sshDev == "true" {
 		if sshDevHost != "" {

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -127,7 +127,10 @@ func (sp ShellProxy) ConnectFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the host and port
-	host := vm.Annotations["sshEndpoint"]
+	host, ok := vm.Annotations["sshEndpoint"]
+	if !ok {
+		host = vm.Status.PublicIP
+	}
 	port := "22"
 	if sshDev == "true" {
 		if sshDevHost != "" {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -221,10 +221,10 @@ func VerifyVMSet(vmSetLister hfListers.VirtualMachineSetLister, vms *hfv1.Virtua
 		var fromCache *hfv1.VirtualMachineSet
 		fromCache, err = vmSetLister.Get(vms.Name)
 		if err != nil {
-			glog.Error(err)
 			if apierrors.IsNotFound(err) {
-				continue
+				return nil
 			}
+			glog.Error(err)
 			return err
 		}
 		if ResourceVersionAtLeast(fromCache.ResourceVersion, vms.ResourceVersion) {
@@ -245,10 +245,10 @@ func VerifyVMClaim(vmClaimLister hfListers.VirtualMachineClaimLister, vmc *hfv1.
 		var fromCache *hfv1.VirtualMachineClaim
 		fromCache, err = vmClaimLister.Get(vmc.Name)
 		if err != nil {
-			glog.Error(err)
 			if apierrors.IsNotFound(err) {
-				continue
+				return nil
 			}
+			glog.Error(err)
 			return err
 		}
 		if ResourceVersionAtLeast(fromCache.ResourceVersion, vmc.ResourceVersion) {
@@ -269,10 +269,10 @@ func VerifySession(sLister hfListers.SessionLister, s *hfv1.Session) error {
 		var fromCache *hfv1.Session
 		fromCache, err = sLister.Get(s.Name)
 		if err != nil {
-			glog.Error(err)
 			if apierrors.IsNotFound(err) {
-				continue
+				return nil
 			}
+			glog.Error(err)
 			return err
 		}
 		if ResourceVersionAtLeast(fromCache.ResourceVersion, s.ResourceVersion) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	mrand "math/rand"
+
 	"github.com/golang/glog"
 	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
 	hfListers "github.com/hobbyfarm/gargantua/pkg/client/listers/hobbyfarm.io/v1"
@@ -18,13 +20,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-	mrand "math/rand"
 
-	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 )
 
 type HTTPMessage struct {
@@ -178,10 +180,10 @@ func VerifyVM(vmLister hfListers.VirtualMachineLister, vm *hfv1.VirtualMachine) 
 		var fromCache *hfv1.VirtualMachine
 		fromCache, err = vmLister.Get(vm.Name)
 		if err != nil {
-			glog.Error(err)
 			if apierrors.IsNotFound(err) {
-				continue
+				return nil
 			}
+			glog.Error(err)
 			return err
 		}
 		if ResourceVersionAtLeast(fromCache.ResourceVersion, vm.ResourceVersion) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Gargantua has a complex logic to try static and dynamic binds. 
This results in a lot of dynamic bind requests being created, when something like a slow api server is preventing the object processing to be completed in time. 
The session server already specifies the VirtualMachineClaims to be dynamic in nature.
This PR cleans up the VirtualMachineClaim controller logic to handle vm interaction and reconcillation within the VMC controller.

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
