### PR TITLE
Fix terminal crash when using vim inside containers

### DIFF
--- a/pkg/shell/wswrapper.go
+++ b/pkg/shell/wswrapper.go
@@ -1,9 +1,11 @@
 package shell
 
 import (
-	"github.com/gorilla/websocket"
 	"io"
 	"sync"
+	"unicode/utf8"
+
+	"github.com/gorilla/websocket"
 )
 
 type WSWrapper struct {
@@ -28,13 +30,32 @@ func (w *WSWrapper) Write(data []byte) (n int, err error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	n = len(data)
-	err = w.ws.WriteMessage(w.mode, data)
+	err = w.ws.WriteMessage(w.mode, validUtf8(data))
 
 	if err != nil {
 		n = 0
 	}
 
 	return n, err
+}
+
+func validUtf8(b []byte) []byte {
+	if !utf8.Valid(b) {
+		s := string(b)
+		v := make([]rune, 0, len(s))
+		for i, r := range s {
+			if r == utf8.RuneError {
+				_, size := utf8.DecodeRuneInString(s[i:])
+				if size == 1 {
+					continue
+				}
+			}
+			v = append(v, r)
+		}
+		s = string(v)
+		return []byte(s)
+	}
+	return b
 }
 
 func (w *WSWrapper) Read(out []byte) (n int, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Vim crashes inside docker containers because its standard encoding is not utf-8 (but latin1). However, [gorilla/websockets](https://github.com/gorilla/websocket) only accepts utf-8 encoded text frames. Therefore, check if text messages written to websocket are encoded in utf-8. If not convert falsy parts to utf-8.

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/154
