### PR TITLE
Categories for scenarios, dynamic scenarios for courses

### DIFF
--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -272,6 +272,8 @@ type ScenarioSpec struct {
 	Name              string              `json:"name"`
 	Description       string              `json:"description"`
 	Steps             []ScenarioStep      `json:"steps"`
+	Categories        []string            `json:"categories"`
+	Tags              []string            `json:"tags"`
 	VirtualMachines   []map[string]string `json:"virtualmachines"`
 	KeepAliveDuration string              `json:"keepalive_duration"`
 	PauseDuration     string              `json:"pause_duration"`

--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -242,6 +242,7 @@ type CourseSpec struct {
 	Name              string              `json:"name"`
 	Description       string              `json:"description"`
 	Scenarios         []string            `json:"scenarios"`
+	Categories        []string            `json:"categories"`
 	VirtualMachines   []map[string]string `json:"virtualmachines"`
 	KeepAliveDuration string              `json:"keepalive_duration"`
 	PauseDuration     string              `json:"pause_duration"`

--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -246,6 +246,7 @@ type CourseSpec struct {
 	KeepAliveDuration string              `json:"keepalive_duration"`
 	PauseDuration     string              `json:"pause_duration"`
 	Pauseable         bool                `json:"pauseable"`
+	KeepVM            bool                `json:"keep_vm"`
 }
 
 // +genclient
@@ -305,12 +306,13 @@ type SessionList struct {
 }
 
 type SessionSpec struct {
-	Id         string   `json:"id"`
-	ScenarioId string   `json:"scenario"`
-	CourseId   string   `json:"course"`
-	UserId     string   `json:"user"`
-	VmClaimSet []string `json:"vm_claim"`
-	AccessCode string   `json:"access_code"`
+	Id           string   `json:"id"`
+	ScenarioId   string   `json:"scenario"`
+	CourseId     string   `json:"course"`
+	KeepCourseVM bool     `json:"keep_course_vm"`
+	UserId       string   `json:"user"`
+	VmClaimSet   []string `json:"vm_claim"`
+	AccessCode   string   `json:"access_code"`
 }
 
 type SessionStatus struct {

--- a/pkg/controllers/scheduledevent/scheduledeventcontroller.go
+++ b/pkg/controllers/scheduledevent/scheduledeventcontroller.go
@@ -202,7 +202,7 @@ func (s ScheduledEventController) deleteVMSetsFromScheduledEvent(se *hfv1.Schedu
 }
 
 func (s ScheduledEventController) finishSessionsFromScheduledEvent(se *hfv1.ScheduledEvent) error {
-	// get a list of sessions for the user
+	// get a list of sessions associated to the scheduledEvent
 	sessionList, err := s.hfClientSet.HobbyfarmV1().Sessions().List(s.ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", sessionserver.AccessCodeLabel, se.Spec.AccessCode),
 	})

--- a/pkg/scenarioserver/scenarioserver.go
+++ b/pkg/scenarioserver/scenarioserver.go
@@ -340,7 +340,7 @@ func (s ScenarioServer) ListCategories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	categories = removeDuplicateValues(categories)
+	categories = util.UniqueStringSlice(categories)
 	sort.Strings(categories)
 
 	encodedCategories, err := json.Marshal(categories)
@@ -350,22 +350,6 @@ func (s ScenarioServer) ListCategories(w http.ResponseWriter, r *http.Request) {
 	util.ReturnHTTPContent(w, r, 200, "success", encodedCategories)
 
 	glog.V(2).Infof("listed categories")
-}
-
-func removeDuplicateValues(stringSlice []string) []string {
-	keys := make(map[string]bool)
-	list := []string{}
-
-	// If the key(values of the slice) is not equal
-	// to the already present value in new slice (list)
-	// then we append it. else we jump on another element.
-	for _, entry := range stringSlice {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
-			list = append(list, entry)
-		}
-	}
-	return list
 }
 
 func (s ScenarioServer) PrintFunc(w http.ResponseWriter, r *http.Request) {

--- a/pkg/scenarioserver/scenarioserver.go
+++ b/pkg/scenarioserver/scenarioserver.go
@@ -533,25 +533,25 @@ func (s ScenarioServer) UpdateFunc(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if rawCategories != "" {
-			categories := []string{}
-			err = json.Unmarshal([]byte(rawCategories), &categories)
+			categoriesSlice := make([]string, 0)
+			err = json.Unmarshal([]byte(rawCategories), &categoriesSlice)
 			if err != nil {
 				glog.Errorf("error while unmarshaling categories %v", err)
 				util.ReturnHTTPMessage(w, r, 500, "internalerror", "error parsing")
 				return fmt.Errorf("bad")
 			}
-			scenario.Spec.Categories = categories
+			scenario.Spec.Categories = categoriesSlice
 		}
 
 		if rawTags != "" {
-			tags := []string{}
-			err = json.Unmarshal([]byte(rawTags), &tags)
+			tagsSlice := make([]string, 0)
+			err = json.Unmarshal([]byte(rawTags), &tagsSlice)
 			if err != nil {
 				glog.Errorf("error while unmarshaling tags %v", err)
 				util.ReturnHTTPMessage(w, r, 500, "internalerror", "error parsing")
 				return fmt.Errorf("bad")
 			}
-			scenario.Spec.Tags = tags
+			scenario.Spec.Tags = tagsSlice
 		}
 
 		_, updateErr := s.hfClientSet.HobbyfarmV1().Scenarios().Update(s.ctx, scenario, metav1.UpdateOptions{})

--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -499,7 +499,7 @@ func (s ScheduledEventServer) deleteVMSetsFromScheduledEvent(se *hfv1.ScheduledE
 }
 
 func (s ScheduledEventServer) finishSessions(se *hfv1.ScheduledEvent) error {
-	// get a list of sessions for the user
+	// get a list of sessions for the event
 	sessionList, err := s.hfClientSet.HobbyfarmV1().Sessions().List(s.ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", sessionserver.AccessCodeLabel, se.Spec.AccessCode),
 	})

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -200,17 +200,12 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 	sessionName := util.GenerateResourceName("ss", random, 10)
 	session := hfv1.Session{}
 
-	var keepCourseVM = true
-	if course.Spec.KeepVM {
-		keepCourseVM = course.Spec.KeepVM
-	}
-
 	session.Name = sessionName
 	session.Spec.Id = sessionName
 	session.Spec.CourseId = course.Spec.Id
 	session.Spec.ScenarioId = scenario.Spec.Id
 	session.Spec.UserId = user.Spec.Id
-	session.Spec.KeepCourseVM = keepCourseVM
+	session.Spec.KeepCourseVM = course.Spec.KeepVM
 	labels := make(map[string]string)
 	labels[AccessCodeLabel] = accessCode    // map accesscode to session
 	labels[UserSessionLabel] = user.Spec.Id // map user to session

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -138,9 +138,10 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// now we should check for existing sessions
-
-	sessions, err := sss.hfClientSet.HobbyfarmV1().Sessions().List(sss.ctx, metav1.ListOptions{})
+	// now we should check for existing sessions for the user
+	sessions, err := sss.hfClientSet.HobbyfarmV1().Sessions().List(sss.ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", UserSessionLabel, user.Spec.Id),
+	})
 
 	if err != nil {
 		glog.Error(err)
@@ -205,7 +206,8 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 	session.Spec.ScenarioId = scenario.Spec.Id
 	session.Spec.UserId = user.Spec.Id
 	labels := make(map[string]string)
-	labels[AccessCodeLabel] = accessCode // map accesscode to session
+	labels[AccessCodeLabel] = accessCode    // map accesscode to session
+	labels[UserSessionLabel] = user.Spec.Id // map user to session
 	session.Labels = labels
 	var vms []map[string]string
 	if course.Spec.VirtualMachines != nil {

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -200,11 +200,17 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 	sessionName := util.GenerateResourceName("ss", random, 10)
 	session := hfv1.Session{}
 
+	var keepCourseVM = true
+	if course.Spec.KeepVM {
+		keepCourseVM = course.Spec.KeepVM
+	}
+
 	session.Name = sessionName
 	session.Spec.Id = sessionName
 	session.Spec.CourseId = course.Spec.Id
 	session.Spec.ScenarioId = scenario.Spec.Id
 	session.Spec.UserId = user.Spec.Id
+	session.Spec.KeepCourseVM = keepCourseVM
 	labels := make(map[string]string)
 	labels[AccessCodeLabel] = accessCode    // map accesscode to session
 	labels[UserSessionLabel] = user.Spec.Id // map user to session


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds categories and tags to scenarios. Categories are also stored as a label to filter scenarios by category.
Adds a new function to retreive all categories in use (For filtering scenarios etc.)

Additionally Courses can now dynamically include Scenarios based on categories.
Supported logical Operations are OR, AND and NOT.
By adding `kubernetes&basic` all scenarios that are in both categories will be selected.
Prepending an exclamation mark in front will select all scenarios that are NOT included in a category.
`kubernetes&!basic` will select all scenarios that are in the kubernetes category and not in the basic category.
I also added some examples to the Admin-UI for further explanation

This additions are needed for Scenarios as Code

