### PR TITLE
Use dynamicBaseNamePrefix

### DIFF
--- a/pkg/apis/hobbyfarm.io/v1/types.go
+++ b/pkg/apis/hobbyfarm.io/v1/types.go
@@ -84,6 +84,7 @@ type VirtualMachineClaimSpec struct {
 	RestrictedBindValue string                           `json:"restricted_bind_value"`
 	VirtualMachines     map[string]VirtualMachineClaimVM `json:"vm"`
 	DynamicCapable      bool                             `json:"dynamic_bind_capable"`
+	BaseName            string			        		 `json:"base_name"`
 }
 
 type VirtualMachineClaimStatus struct {

--- a/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
+++ b/pkg/controllers/vmclaimcontroller/vmclaimcontroller.go
@@ -308,7 +308,7 @@ func (v *VMClaimController) submitVirtualMachines(vmc *hfv1.VirtualMachineClaim)
 	}
 	vmMap := make(map[string]hfv1.VirtualMachineClaimVM)
 	for vmName, vmDetails := range vmc.Spec.VirtualMachines {
-		genName := fmt.Sprintf("%s-%08x", vmc.Name, rand.Uint32())
+		genName := fmt.Sprintf("%s-%08x", vmc.Spec.BaseName, rand.Uint32())
 		vm := &hfv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: genName,

--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -228,16 +229,29 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var bindMode string
+	var baseName string
 	if schedEvent.Spec.OnDemand {
 		bindMode = "dynamic"
+		bndp := os.Getenv("HF_BASENAME_DYNAMIC_PREFIX")
+		if bndp == "" {
+			baseName = "vmc"
+		} else {
+			baseName = bndp
+		}
 	} else {
 		bindMode = "static"
+		bnsp := os.Getenv("HF_BASENAME_SCHEDULED_PREFIX")
+		if bnsp == "" {
+			baseName = "scheduled"
+		} else {
+			baseName = bnsp
+		}
 	}
 
 	session.Spec.VmClaimSet = make([]string, len(vms))
 	for index, vmset := range vms {
 		virtualMachineClaim := hfv1.VirtualMachineClaim{}
-		vmcId := util.GenerateResourceName("vmc", util.RandStringRunes(10), 10)
+		vmcId := util.GenerateResourceName(baseName, util.RandStringRunes(10), 10)
 		labels := make(map[string]string)
 		labels[vmcSessionLabel] = session.Name  // map vmc to session
 		labels[UserSessionLabel] = user.Spec.Id // map session to user in a way that is searchable
@@ -245,6 +259,7 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 		labels[ScheduledEventLabel] = schedEvent.Name
 		virtualMachineClaim.Labels = labels
 		virtualMachineClaim.Spec.Id = vmcId
+		virtualMachineClaim.Spec.BaseName = vmcId
 		virtualMachineClaim.Name = vmcId
 		virtualMachineClaim.Spec.VirtualMachines = make(map[string]hfv1.VirtualMachineClaimVM)
 		for vmName, vmTemplateName := range vmset {


### PR DESCRIPTION
**What this PR does / why we need it**:
Will prefix VMCs and Virtualmachines with dynamicBaseNamePrefix. Scheduled BaseName was always used for static provisioning. Dynamic provisioning however ignored the prefix.

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/167

