### PR TITLE
Revert leader election

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/tools v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -359,7 +359,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"os"
 
 	"github.com/hobbyfarm/gargantua/pkg/scheduledeventserver"
@@ -223,6 +220,79 @@ func main() {
 	http.Handle("/", r)
 
 	var wg sync.WaitGroup
+	if !disableControllers {
+		/*
+			environmentController, err := environment.NewEnvironmentController(hfClient, hfInformerFactory)
+			if err != nil {
+				glog.Fatal(err)
+			}
+		*/
+		glog.V(2).Infof("Starting controllers")
+		sessionController, err := session.NewSessionController(hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		scheduledEventController, err := scheduledevent.NewScheduledEventController(hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		vmClaimController, err := vmclaimcontroller.NewVMClaimController(hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		tfpController, err := tfpcontroller.NewTerraformProvisionerController(kubeClient, hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		vmSetController, err := vmsetcontroller.NewVirtualMachineSetController(hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+
+		dynamicBindController, err := dynamicbindcontroller.NewDynamicBindController(hfClient, hfInformerFactory, ctx)
+		if err != nil {
+			glog.Fatal(err)
+		}
+
+		wg.Add(6)
+		/*
+			go func() {
+				defer wg.Done()
+				environmentController.Run(stopCh)
+			}()
+		*/
+		go func() {
+			defer wg.Done()
+			sessionController.Run(stopCh)
+		}()
+
+		go func() {
+			defer wg.Done()
+			scheduledEventController.Run(stopCh)
+		}()
+
+		go func() {
+			defer wg.Done()
+			vmClaimController.Run(stopCh)
+		}()
+
+		go func() {
+			defer wg.Done()
+			tfpController.Run(stopCh)
+		}()
+
+		go func() {
+			defer wg.Done()
+			vmSetController.Run(stopCh)
+		}()
+
+		go func() {
+			defer wg.Done()
+			dynamicBindController.Run(stopCh)
+		}()
+	}
+
+	hfInformerFactory.Start(stopCh)
 
 	wg.Add(1)
 
@@ -237,111 +307,6 @@ func main() {
 		glog.Fatal(http.ListenAndServe(":"+port, handlers.CORS(corsHeaders, corsOrigins, corsMethods)(r)))
 	}()
 
-	lock, err := getLock(cfg)
-	if err != nil {
-		glog.Fatal(err)
-	}
-	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-		Lock:            lock,
-		ReleaseOnCancel: true,
-		LeaseDuration:   30 * time.Second,
-		RenewDeadline:   15 * time.Second,
-		RetryPeriod:     2 * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(c context.Context) {
-				err = bootStrapControllers(kubeClient, hfClient, hfInformerFactory, ctx, stopCh)
-				if err != nil {
-					glog.Fatal(err)
-				}
-			},
-			OnStoppedLeading: func() {
-				glog.Info("waiting to be elected leader")
-			},
-			OnNewLeader: func(current_id string) {
-				if current_id == lock.Identity() {
-					glog.Info("currently the leader")
-					return
-				}
-				glog.Infof("current leader is %s", current_id)
-			},
-		},
-	})
 	wg.Wait()
-}
 
-func bootStrapControllers(kubeClient *kubernetes.Clientset, hfClient *hfClientset.Clientset,
-	hfInformerFactory hfInformers.SharedInformerFactory, ctx context.Context, stopCh <-chan struct{}) error {
-	g, gctx := errgroup.WithContext(ctx)
-	glog.V(2).Infof("Starting controllers")
-	sessionController, err := session.NewSessionController(hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-	scheduledEventController, err := scheduledevent.NewScheduledEventController(hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-	vmClaimController, err := vmclaimcontroller.NewVMClaimController(hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-	tfpController, err := tfpcontroller.NewTerraformProvisionerController(kubeClient, hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-	vmSetController, err := vmsetcontroller.NewVirtualMachineSetController(hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-
-	dynamicBindController, err := dynamicbindcontroller.NewDynamicBindController(hfClient, hfInformerFactory, gctx)
-	if err != nil {
-		return err
-	}
-
-	g.Go(func() error {
-		return sessionController.Run(stopCh)
-	})
-
-	g.Go(func() error {
-		return scheduledEventController.Run(stopCh)
-	})
-
-	g.Go(func() error {
-		return vmClaimController.Run(stopCh)
-	})
-
-	g.Go(func() error {
-		return tfpController.Run(stopCh)
-	})
-
-	g.Go(func() error {
-		return vmSetController.Run(stopCh)
-	})
-
-	g.Go(func() error {
-		return dynamicBindController.Run(stopCh)
-	})
-
-	hfInformerFactory.Start(stopCh)
-
-	if err = g.Wait(); err != nil {
-		glog.Errorf("error starting up the controllers: %v", err)
-		return err
-	}
-
-	return nil
-}
-
-func getLock(cfg *rest.Config) (resourcelock.Interface, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
-	ns := os.Getenv("NAMESPACE")
-	if ns == "" {
-		ns = "hobbyfarm"
-	}
-	return resourcelock.NewFromKubeconfig(resourcelock.ConfigMapsLeasesResourceLock, ns, "gargantua-leader", resourcelock.ResourceLockConfig{Identity: hostname}, cfg, 15*time.Second)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Leader Election brings some trouble with the shell proxy. We would have to revert it in order to get the master back running.