### PR TITLE
bumped crd version

### DIFF
--- a/artifacts/crd/accesscode.yaml
+++ b/artifacts/crd/accesscode.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: accesscodes.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: AccessCode
     plural: accesscodes

--- a/artifacts/crd/course.yaml
+++ b/artifacts/crd/course.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: courses.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+  - name: v1
+    storage: true
+    served: true
   names:
     kind: Course
     plural: courses

--- a/artifacts/crd/dynamicbindconfiguration.yaml
+++ b/artifacts/crd/dynamicbindconfiguration.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicbindconfigurations.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
   names:
     kind: DynamicBindConfiguration
     plural: dynamicbindconfigurations

--- a/artifacts/crd/dynamicbindrequest.yaml
+++ b/artifacts/crd/dynamicbindrequest.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicbindrequests.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+  - name: v1
+    storage: true
+    served: true
   names:
     kind: DynamicBindRequest
     plural: dynamicbindrequests

--- a/artifacts/crd/environment.yaml
+++ b/artifacts/crd/environment.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: environments.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
   names:
     kind: Environment
     plural: environments

--- a/artifacts/crd/scenario.yaml
+++ b/artifacts/crd/scenario.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scenarios.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: Scenario
     plural: scenarios

--- a/artifacts/crd/scheduledevent.yaml
+++ b/artifacts/crd/scheduledevent.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scheduledevents.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
   names:
     kind: ScheduledEvent
     plural: scheduledevents

--- a/artifacts/crd/session.yaml
+++ b/artifacts/crd/session.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: sessions.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+  - name: v1
+    storage: true
+    served: true
   names:
     kind: Session
     plural: sessions

--- a/artifacts/crd/user.yaml
+++ b/artifacts/crd/user.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: users.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: User
     plural: users

--- a/artifacts/crd/virtualmachine.yaml
+++ b/artifacts/crd/virtualmachine.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachines.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
   names:
     kind: VirtualMachine
     plural: virtualmachines

--- a/artifacts/crd/virtualmachineclaim.yaml
+++ b/artifacts/crd/virtualmachineclaim.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachineclaims.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: VirtualMachineClaim
     plural: virtualmachineclaims

--- a/artifacts/crd/virtualmachineset.yaml
+++ b/artifacts/crd/virtualmachineset.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachinesets.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: VirtualMachineSet
     plural: virtualmachinesets

--- a/artifacts/crd/virtualmachinetemplate.yaml
+++ b/artifacts/crd/virtualmachinetemplate.yaml
@@ -1,10 +1,13 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: virtualmachinetemplates.hobbyfarm.io
 spec:
   group: hobbyfarm.io
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
   names:
     kind: VirtualMachineTemplate
     plural: virtualmachinetemplates


### PR DESCRIPTION
**What this PR does / why we need it**: bumps crd versions to be compatible with api deprecations

**Which issue(s) this PR fixes**: hobbyfarm/hobbyfarm#176

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
