### PR TITLE
Start informer factory for shell server

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,6 +290,9 @@ func main() {
 				},
 			},
 		})
+	} else {
+		// default fire up hfInformer as this is still needed by the shell server
+		hfInformerFactory.Start(stopCh)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where shell server is unable to lookup users post the leader election fixes

By default the shared informers are not started if controllers are disabled, however they are needed by the shell server, hence this change.

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
