### PR TITLE
Allow duplicate names on ScheduledEvent

### DIFF
--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -247,11 +247,8 @@ func (s ScheduledEventServer) CreateFunc(w http.ResponseWriter, r *http.Request)
 	}
 
 	scheduledEvent := &hfv1.ScheduledEvent{}
-
-	hasher := sha256.New()
-	hasher.Write([]byte(name))
-	sha := base32.StdEncoding.WithPadding(-1).EncodeToString(hasher.Sum(nil))[:10]
-	scheduledEvent.Name = "se-" + strings.ToLower(sha)
+	random := util.RandStringRunes(16)
+	scheduledEvent.Name = "se-" + util.GenerateResourceName("se", random, 10)
 
 	scheduledEvent.Spec.Name = name
 	scheduledEvent.Spec.Description = description


### PR DESCRIPTION
**What this PR does / why we need it**:
Creating two events with the same name fails in a silent 500 Error due to the CRD Name being generated based on the name of the Event. 
For example if a event was finished a long time ago it would be ok to create a second event with the same name.
Also for RBAC this should be important.


This PR rewrites the CRD name generation for events, making it more random and not based on the SE name.

