### PR TITLE
Fix VMSet Update bug

### DIFF
--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -367,6 +367,11 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 		provisionedCount++
 	}
 
+	if(provisionedCount < vmset.Spec.Count){
+		glog.V(4).Infof("requeing VMset as there are not enough VMs ready")
+		v.enqueueVMSet(vmset)
+	}
+
 	err = v.updateVMSetCount(vmset.Name, activeCount, provisionedCount)
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
/fixes https://github.com/hobbyfarm/hobbyfarm/issues/205

The problem was that updating an ScheduledEvent which already had VMSets was missing an `vmSets = append(vmSets, existingVMSet.Name)` to keep the VMSet in the list of existing VMSets for an SE. This was leading to an empty list of vmsets, and therefore the creation of a new VMset on the next update.

Every second update was creating a new VMSet. 

This PR also fixes a problem where Events with more than one VMSet could not be updated. (Only one VMSet could be updated)
<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
