### PR TITLE
Map rolebindings to id instead of username

### DIFF
--- a/pkg/authclient/authclient.go
+++ b/pkg/authclient/authclient.go
@@ -99,7 +99,7 @@ func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv1.User) (hf
 	if request.GetOperator() == rbacclient.OperatorAnd {
 		// operator AND, all need to match
 		for _, p := range request.GetPermissions() {
-			g, err := a.rbacServer.Grants(user.Spec.Email, p)
+			g, err := a.rbacServer.Grants(user.Name, p)
 			if err != nil {
 				return hfv1.User{}, err
 			}
@@ -113,7 +113,7 @@ func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv1.User) (hf
 	} else {
 		// operator OR, only one needs to match
 		for _, p := range request.GetPermissions() {
-			g, err := a.rbacServer.Grants(user.Spec.Email, p)
+			g, err := a.rbacServer.Grants(user.Name, p)
 			if err != nil {
 				return hfv1.User{}, err
 			}

--- a/pkg/authserver/authserver.go
+++ b/pkg/authserver/authserver.go
@@ -591,7 +591,7 @@ func (a *AuthServer) GetAccessSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// need to get the user's access set and publish to front end
-	as, err := a.rbac.GetAccessSet(user.Spec.Email)
+	as, err := a.rbac.GetAccessSet(user.Name)
 	if err != nil {
 		util.ReturnHTTPMessage(w, r, http.StatusInternalServerError, "internalerror", "internal error fetching access set")
 		glog.Error(err)

--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -299,7 +299,7 @@ func (s ScheduledEventServer) CreateFunc(w http.ResponseWriter, r *http.Request)
 }
 
 func (s ScheduledEventServer) UpdateFunc(w http.ResponseWriter, r *http.Request) {
-	user, err := s.auth.AuthGrant(rbacclient.RbacRequest().HobbyfarmPermission(resourcePlural, rbacclient.VerbUpdate), w, r)
+	_, err := s.auth.AuthGrant(rbacclient.RbacRequest().HobbyfarmPermission(resourcePlural, rbacclient.VerbUpdate), w, r)
 	if err != nil {
 		util.ReturnHTTPMessage(w, r, 403, "forbidden", "no access to update scheduledevents")
 		return
@@ -318,11 +318,6 @@ func (s ScheduledEventServer) UpdateFunc(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			glog.Error(err)
 			util.ReturnHTTPMessage(w, r, 404, "badrequest", "no scheduledEvent found with given ID")
-			return fmt.Errorf("bad")
-		}
-
-		if scheduledEvent.Spec.Creator != user.Spec.Id {
-			util.ReturnHTTPMessage(w, r, 403, "forbidden", "not creator")
 			return fmt.Errorf("bad")
 		}
 
@@ -475,7 +470,7 @@ func (s ScheduledEventServer) UpdateFunc(w http.ResponseWriter, r *http.Request)
 }
 
 func (s ScheduledEventServer) DeleteFunc(w http.ResponseWriter, r *http.Request) {
-	user, err := s.auth.AuthGrant(rbacclient.RbacRequest().HobbyfarmPermission(resourcePlural, rbacclient.VerbDelete), w, r)
+	_, err := s.auth.AuthGrant(rbacclient.RbacRequest().HobbyfarmPermission(resourcePlural, rbacclient.VerbDelete), w, r)
 	if err != nil {
 		util.ReturnHTTPMessage(w, r, 403, "forbidden", "no access to delete scheduledevents")
 		return
@@ -493,11 +488,6 @@ func (s ScheduledEventServer) DeleteFunc(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		glog.Error(err)
 		util.ReturnHTTPMessage(w, r, 404, "badrequest", "no scheduledEvent found with given ID")
-		return
-	}
-
-	if scheduledEvent.Spec.Creator != user.Spec.Id {
-		util.ReturnHTTPMessage(w, r, 403, "forbidden", "not creator")
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
RoleBindings are now mapped to ID instead of email.
Also removed a check on scheduled events which is unnecessary with the new rbac feature.

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/210