### PR TITLE
Add/Rename missing fields in typed CRDs

### DIFF
--- a/artifacts/typedCRD/crd.yaml
+++ b/artifacts/typedCRD/crd.yaml
@@ -33,11 +33,14 @@ spec:
               id:
                 nullable: true
                 type: string
-              keypair_name:
+              secret_name:
                 nullable: true
                 type: string
               provision:
                 type: boolean
+              protocol:
+                nullable: true
+                type: string
               ssh_username:
                 nullable: true
                 type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Protocl field to Virtualmachine, renames keypair_name to secret_name