### PR TITLE
Remove expiredOk for GetAccessCode

### DIFF
--- a/pkg/scenarioserver/scenarioserver.go
+++ b/pkg/scenarioserver/scenarioserver.go
@@ -126,7 +126,7 @@ func (s ScenarioServer) getPrintableScenarioIds(accessCodes []string) []string {
 	var printableScenarioIds []string
 	var printableCourseIds []string
 	for _, acString := range accessCodes {
-		ac, err := s.acClient.GetAccessCode(acString, false)
+		ac, err := s.acClient.GetAccessCode(acString)
 		if err != nil {
 			glog.Errorf("error retrieving access code: %s %v", acString, err)
 			continue
@@ -286,7 +286,7 @@ func (s ScenarioServer) ListScenarioForAccessCodes(w http.ResponseWriter, r *htt
 	var scenarioIds []string
 	var printableScenarioIds []string
 	for _, acString := range user.Spec.AccessCodes {
-		ac, err := s.acClient.GetAccessCode(acString, false)
+		ac, err := s.acClient.GetAccessCode(acString)
 		if err != nil {
 			glog.Errorf("error retrieving access code: %s %v", acString, err)
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
No other value than "false" was passed in to expiredOk parameter. Removing it.

**Which issue(s) this PR fixes**:
fixes https://github.com/hobbyfarm/hobbyfarm/issues/120
