### PR TITLE
Fix for 275

### DIFF
--- a/pkg/controllers/scheduledevent/scheduledeventcontroller.go
+++ b/pkg/controllers/scheduledevent/scheduledeventcontroller.go
@@ -218,6 +218,18 @@ func (s ScheduledEventController) deleteProgressFromScheduledEvent(se *hfv1.Sche
 	return nil
 }
 
+func (s ScheduledEventController) deleteAccessCode(se *hfv1.ScheduledEvent) error {
+	// for each vmset that belongs to this to-be-stopped scheduled event, delete that vmset
+	err := s.hfClientSet.HobbyfarmV1().AccessCodes(util.GetReleaseNamespace()).DeleteCollection(s.ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", util.ScheduledEventLabel, se.Name),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s ScheduledEventController) finishSessionsFromScheduledEvent(se *hfv1.ScheduledEvent) error {
 	// get a list of sessions for the user
 	sessionList, err := s.hfClientSet.HobbyfarmV1().Sessions(util.GetReleaseNamespace()).List(s.ctx, metav1.ListOptions{
@@ -371,6 +383,14 @@ func (s ScheduledEventController) provisionScheduledEvent(templates *hfv1.Virtua
 			}
 		}
 
+		// Delete existing DynamicBindConfigurations
+		err = s.hfClientSet.HobbyfarmV1().DynamicBindConfigurations(util.GetReleaseNamespace()).DeleteCollection(s.ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s,environment=%s", util.ScheduledEventLabel, se.Name, env.Name),
+		})
+		if err != nil {
+			return err
+		}
+
 		// create the dynamic bind configurations
 		dbcRand := fmt.Sprintf("%s-%08x", baseNameDynamicPrefix, rand.Uint32())
 		dbcName := strings.Join([]string{"se", se.Name, "dbc", dbcRand}, "-")
@@ -432,7 +452,16 @@ func (s ScheduledEventController) provisionScheduledEvent(templates *hfv1.Virtua
 		}
 	}
 
-	err := s.createAccessCode(se)
+	// Delete AccessCode if it exists
+	_, err := s.hfClientSet.HobbyfarmV1().AccessCodes(util.GetReleaseNamespace()).Get(s.ctx, se.Spec.AccessCode, metav1.GetOptions{})
+	if err == nil {
+		err = s.deleteAccessCode(se)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.createAccessCode(se)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/scheduledevent/scheduledeventcontroller.go
+++ b/pkg/controllers/scheduledevent/scheduledeventcontroller.go
@@ -588,6 +588,10 @@ func (s ScheduledEventController) verifyScheduledEvent(se *hfv1.ScheduledEvent) 
 			return err
 		}
 
+		if seToUpdate.Status.Provisioned == false || seToUpdate.Status.Finished == true {
+			return fmt.Errorf("scheduled event is not provisioned. Maybe changed recently")
+		}
+
 		seToUpdate.Status.Provisioned = true
 		seToUpdate.Status.Ready = true
 		seToUpdate.Status.Finished = false

--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -457,17 +457,18 @@ func (s ScheduledEventServer) UpdateFunc(w http.ResponseWriter, r *http.Request)
 			if err != nil {
 				return err
 			}
-			scheduledEvent.Status.Provisioned = false
-			scheduledEvent.Status.Ready = false
-			scheduledEvent.Status.Finished = false
 		}
 
-		_, updateErr := s.hfClientSet.HobbyfarmV1().ScheduledEvents(util.GetReleaseNamespace()).Update(s.ctx, scheduledEvent, metav1.UpdateOptions{})
+		updateSE, updateErr := s.hfClientSet.HobbyfarmV1().ScheduledEvents(util.GetReleaseNamespace()).Update(s.ctx, scheduledEvent, metav1.UpdateOptions{})
 		if(updateErr != nil){
 			return updateErr
 		}
 
-		_, updateErr = s.hfClientSet.HobbyfarmV1().ScheduledEvents(util.GetReleaseNamespace()).UpdateStatus(s.ctx, scheduledEvent, metav1.UpdateOptions{})
+		updateSE.Status.Provisioned = false
+		updateSE.Status.Ready = false
+		updateSE.Status.Finished = false
+
+		_, updateErr = s.hfClientSet.HobbyfarmV1().ScheduledEvents(util.GetReleaseNamespace()).UpdateStatus(s.ctx, updateSE, metav1.UpdateOptions{})
 		return updateErr
 	})
 

--- a/pkg/scheduledeventserver/scheduledevent.go
+++ b/pkg/scheduledeventserver/scheduledevent.go
@@ -473,6 +473,7 @@ func (s ScheduledEventServer) UpdateFunc(w http.ResponseWriter, r *http.Request)
 	})
 
 	if retryErr != nil {
+		glog.Error(retryErr)
 		util.ReturnHTTPMessage(w, r, 500, "error", "error attempting to update")
 		return
 	}


### PR DESCRIPTION
Checks if accessCode / DynamicBind Configuration already exists when provisioning a scheduledEvent. Will delete them if they exist. 
Otherwise there can be a sideeffect when updating ScheduledEvents

fixes [275](https://github.com/hobbyfarm/hobbyfarm/issues/275)