### PR TITLE
Wrong protocol used on vmsets

### DIFF
--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -315,7 +315,7 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 			if exists {
 				vm.Spec.SshUsername = sshUser
 			}
-			protocol, exists := env.Spec.TemplateMapping[vmt.Name]["protocol"]
+			protocol, exists := config["protocol"]
 			if exists {
 				vm.Spec.Protocol = protocol
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
On VMSets the wrong protocol is used. It does not take protocols from the VMT into account
