### PR TITLE
VM Service proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"os"
+
 	"github.com/ebauman/crder"
 	"github.com/hobbyfarm/gargantua/pkg/crd"
 	"github.com/hobbyfarm/gargantua/pkg/rbac"
@@ -11,13 +13,13 @@ import (
 	"github.com/hobbyfarm/gargantua/pkg/rbacserver"
 	tls2 "github.com/hobbyfarm/gargantua/pkg/tls"
 	"github.com/hobbyfarm/gargantua/pkg/webhook/conversion"
+	"github.com/hobbyfarm/gargantua/pkg/webhook/conversion/user"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"os"
 
 	"github.com/hobbyfarm/gargantua/pkg/scheduledeventserver"
 	"github.com/hobbyfarm/gargantua/pkg/vmtemplateserver"
@@ -304,6 +306,7 @@ func main() {
 
 	// shell server does not serve webhook endpoint, so don't start it
 	if !shellServer {
+		user.Init()
 		conversionRouter := mux.NewRouter()
 		conversion.New(conversionRouter, apiExtensionsClient, string(ca))
 

--- a/pkg/accesscode/accesscode.go
+++ b/pkg/accesscode/accesscode.go
@@ -3,13 +3,14 @@ package accesscode
 import (
 	"context"
 	"fmt"
+	"sort"
+	"time"
+
 	"github.com/golang/glog"
 	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	"github.com/hobbyfarm/gargantua/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sort"
-	"time"
 )
 
 type AccessCodeClient struct {
@@ -131,7 +132,7 @@ func (acc AccessCodeClient) GetCourseIds(code string) ([]string, error) {
 func (acc AccessCodeClient) GetClosestAccessCode(userID string, scenarioOrCourseId string) (string, error) {
 	// basically let's get all of the access codes, sort them by expiration, and start going down the list looking for access codes.
 
-	user, err := acc.hfClientSet.HobbyfarmV1().Users(util.GetReleaseNamespace()).Get(acc.ctx, userID, metav1.GetOptions{}) // @TODO: FIX THIS TO NOT DIRECTLY CALL USER
+	user, err := acc.hfClientSet.HobbyfarmV2().Users(util.GetReleaseNamespace()).Get(acc.ctx, userID, metav1.GetOptions{}) // @TODO: FIX THIS TO NOT DIRECTLY CALL USER
 
 	if err != nil {
 		return "", fmt.Errorf("error retrieving user: %v", err)

--- a/pkg/authclient/authclient.go
+++ b/pkg/authclient/authclient.go
@@ -2,15 +2,16 @@ package authclient
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/golang/glog"
-	hfv1 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
+	hfv2 "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v2"
 	hfClientset "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	hfInformers "github.com/hobbyfarm/gargantua/pkg/client/informers/externalversions"
 	"github.com/hobbyfarm/gargantua/pkg/rbacclient"
 	"k8s.io/client-go/tools/cache"
-	"net/http"
-	"strings"
 )
 
 const (
@@ -26,7 +27,7 @@ type AuthClient struct {
 func NewAuthClient(hfClientSet hfClientset.Interface, hfInformerFactory hfInformers.SharedInformerFactory, rbacServer *rbacclient.Client) (*AuthClient, error) {
 	a := AuthClient{}
 	a.hfClientSet = hfClientSet
-	inf := hfInformerFactory.Hobbyfarm().V1().Users().Informer()
+	inf := hfInformerFactory.Hobbyfarm().V2().Users().Informer()
 	indexers := map[string]cache.IndexFunc{emailIndex: emailIndexer}
 	inf.AddIndexers(indexers)
 	a.userIndexer = inf.GetIndexer()
@@ -35,44 +36,44 @@ func NewAuthClient(hfClientSet hfClientset.Interface, hfInformerFactory hfInform
 }
 
 func emailIndexer(obj interface{}) ([]string, error) {
-	user, ok := obj.(*hfv1.User)
+	user, ok := obj.(*hfv2.User)
 	if !ok {
 		return []string{}, nil
 	}
 	return []string{user.Spec.Email}, nil
 }
 
-func (a AuthClient) getUserByEmail(email string) (hfv1.User, error) {
+func (a AuthClient) getUserByEmail(email string) (hfv2.User, error) {
 	if len(email) == 0 {
-		return hfv1.User{}, fmt.Errorf("email passed in was empty")
+		return hfv2.User{}, fmt.Errorf("email passed in was empty")
 	}
 
 	obj, err := a.userIndexer.ByIndex(emailIndex, email)
 	if err != nil {
-		return hfv1.User{}, fmt.Errorf("error while retrieving user by e-mail: %s with error: %v", email, err)
+		return hfv2.User{}, fmt.Errorf("error while retrieving user by e-mail: %s with error: %v", email, err)
 	}
 
 	if len(obj) < 1 {
-		return hfv1.User{}, fmt.Errorf("user not found by email: %s", email)
+		return hfv2.User{}, fmt.Errorf("user not found by email: %s", email)
 	}
 
-	user, ok := obj[0].(*hfv1.User)
+	user, ok := obj[0].(*hfv2.User)
 
 	if !ok {
-		return hfv1.User{}, fmt.Errorf("error while converting user found by email to object: %s", email)
+		return hfv2.User{}, fmt.Errorf("error while converting user found by email to object: %s", email)
 	}
 
 	return *user, nil
 
 }
 
-func (a AuthClient) AuthWS(w http.ResponseWriter, r *http.Request) (hfv1.User, error) {
+func (a AuthClient) AuthWS(w http.ResponseWriter, r *http.Request) (hfv2.User, error) {
 	token := r.URL.Query().Get("auth")
 
 	if len(token) == 0 {
 		glog.Errorf("no auth token passed in websocket query string")
 		//util.ReturnHTTPMessage(w, r, 403, "forbidden", "no token passed")
-		return hfv1.User{}, fmt.Errorf("authentication failed")
+		return hfv2.User{}, fmt.Errorf("authentication failed")
 	}
 
 	return a.performAuth(token)
@@ -80,7 +81,7 @@ func (a AuthClient) AuthWS(w http.ResponseWriter, r *http.Request) (hfv1.User, e
 
 // if admin is true then check if user is an admin
 
-func (a AuthClient) performAuth(token string) (hfv1.User, error) {
+func (a AuthClient) performAuth(token string) (hfv2.User, error) {
 	//glog.V(2).Infof("token passed in was: %s", token)
 
 	user, err := a.ValidateJWT(token)
@@ -88,24 +89,24 @@ func (a AuthClient) performAuth(token string) (hfv1.User, error) {
 	if err != nil {
 		glog.Errorf("error validating user %v", err)
 		//util.ReturnHTTPMessage(w, r, 403, "forbidden", "forbidden")
-		return hfv1.User{}, fmt.Errorf("authentication failed")
+		return hfv2.User{}, fmt.Errorf("authentication failed")
 	}
 
 	glog.V(2).Infof("validated user %s!", user.Spec.Email)
 	return user, nil
 }
 
-func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv1.User) (hfv1.User, error) {
+func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv2.User) (hfv2.User, error) {
 	if request.GetOperator() == rbacclient.OperatorAnd {
 		// operator AND, all need to match
 		for _, p := range request.GetPermissions() {
 			g, err := a.rbacServer.Grants(user.Name, p)
 			if err != nil {
-				return hfv1.User{}, err
+				return hfv2.User{}, err
 			}
 
 			if !g {
-				return hfv1.User{}, fmt.Errorf("permission denied")
+				return hfv2.User{}, fmt.Errorf("permission denied")
 			}
 		}
 		// if we get here, AND has succeeded
@@ -115,7 +116,7 @@ func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv1.User) (hf
 		for _, p := range request.GetPermissions() {
 			g, err := a.rbacServer.Grants(user.Name, p)
 			if err != nil {
-				return hfv1.User{}, err
+				return hfv2.User{}, err
 			}
 
 			if g {
@@ -124,10 +125,10 @@ func (a *AuthClient) VerifyRBAC(request *rbacclient.Request, user hfv1.User) (hf
 		}
 	}
 
-	return hfv1.User{}, fmt.Errorf("permission denied")
+	return hfv2.User{}, fmt.Errorf("permission denied")
 }
 
-func (a *AuthClient) AuthGrantWS(request *rbacclient.Request, w http.ResponseWriter, r *http.Request) (hfv1.User, error) {
+func (a *AuthClient) AuthGrantWS(request *rbacclient.Request, w http.ResponseWriter, r *http.Request) (hfv2.User, error) {
 	user, err := a.AuthWS(w, r)
 	if err != nil {
 		return user, err
@@ -136,7 +137,7 @@ func (a *AuthClient) AuthGrantWS(request *rbacclient.Request, w http.ResponseWri
 	return a.VerifyRBAC(request, user)
 }
 
-func (a *AuthClient) AuthGrant(request *rbacclient.Request, w http.ResponseWriter, r *http.Request) (hfv1.User, error) {
+func (a *AuthClient) AuthGrant(request *rbacclient.Request, w http.ResponseWriter, r *http.Request) (hfv2.User, error) {
 	user, err := a.AuthN(w, r)
 	if err != nil {
 		return user, err
@@ -145,13 +146,13 @@ func (a *AuthClient) AuthGrant(request *rbacclient.Request, w http.ResponseWrite
 	return a.VerifyRBAC(request, user)
 }
 
-func (a AuthClient) AuthN(w http.ResponseWriter, r *http.Request) (hfv1.User, error) {
+func (a AuthClient) AuthN(w http.ResponseWriter, r *http.Request) (hfv2.User, error) {
 	token := r.Header.Get("Authorization")
 
 	if len(token) == 0 {
 		glog.Errorf("no bearer token passed")
 		//util.ReturnHTTPMessage(w, r, 403, "forbidden", "no token passed")
-		return hfv1.User{}, fmt.Errorf("authentication failed")
+		return hfv2.User{}, fmt.Errorf("authentication failed")
 	}
 
 	var finalToken string
@@ -162,19 +163,19 @@ func (a AuthClient) AuthN(w http.ResponseWriter, r *http.Request) (hfv1.User, er
 	return a.performAuth(finalToken)
 }
 
-func (a AuthClient) ValidateJWT(tokenString string) (hfv1.User, error) {
+func (a AuthClient) ValidateJWT(tokenString string) (hfv2.User, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		// Don't forget to validate the alg is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
-		var user hfv1.User
+		var user hfv2.User
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {
 			var err error
 			user, err = a.getUserByEmail(fmt.Sprint(claims["email"]))
 			if err != nil {
 				glog.Errorf("could not find user that matched email %s", fmt.Sprint(claims["email"]))
-				return hfv1.User{}, fmt.Errorf("could not find user that matched token %s", fmt.Sprint(claims["email"]))
+				return hfv2.User{}, fmt.Errorf("could not find user that matched token %s", fmt.Sprint(claims["email"]))
 			}
 		}
 		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
@@ -183,17 +184,17 @@ func (a AuthClient) ValidateJWT(tokenString string) (hfv1.User, error) {
 
 	if err != nil {
 		glog.Errorf("error while validating user: %v", err)
-		return hfv1.User{}, err
+		return hfv2.User{}, err
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		user, err := a.getUserByEmail(fmt.Sprint(claims["email"]))
 		if err != nil {
-			return hfv1.User{}, err
+			return hfv2.User{}, err
 		} else {
 			return user, nil
 		}
 	}
 	glog.Errorf("error while validating user")
-	return hfv1.User{}, fmt.Errorf("error while validating user")
+	return hfv2.User{}, fmt.Errorf("error while validating user")
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -85,7 +85,7 @@ func (sp ShellProxy) SetupRoutes(r *mux.Router) {
 func (sp ShellProxy) ConnectToPortFunc(w http.ResponseWriter, r *http.Request) {
 	// Get variables from Request
 	vars := mux.Vars(r)
-	// Get the auth Variable, built an Authorization Header that can be handled by AuthN
+	// Get the auth Variable, build an Authorization Header that can be handled by AuthN
 	authToken := vars["auth"]
 	r.Header.Add("Authorization", "Bearer "+authToken)
 	user, err := sp.auth.AuthN(w, r)
@@ -109,7 +109,7 @@ func (sp ShellProxy) ConnectToPortFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if vm.Spec.UserId != user.Spec.Id {
-		// check if the user has access to access user sessions
+		// check if the user has access to user sessions
 		_, err := sp.auth.AuthGrantWS(
 			rbacclient.RbacRequest().
 				HobbyfarmPermission("users", rbacclient.VerbGet).
@@ -122,13 +122,13 @@ func (sp ShellProxy) ConnectToPortFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// Get the target Port variable, default to 8080
-	tPort := vars["port"]
-	if tPort == "" {
-		tPort = "8080"
+	// Get the target Port variable, default to 80
+	targetPort := vars["port"]
+	if targetPort == "" {
+		targetPort = "80"
 	}
 	// Build URL and Proxy to forward the Request to
-	target := "http://127.0.0.1:" + tPort
+	target := "http://127.0.0.1:" + targetPort
 	remote, err := url.Parse(target)
 	if err != nil {
 		util.ReturnHTTPMessage(w, r, 500, "error", "unable to parse URL for Localhost")
@@ -200,7 +200,7 @@ func (sp ShellProxy) ConnectToPortFunc(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = mux.Vars(r)["rest"]
 
 	// Handle Response before returning to original Client
-	proxy.ModifyResponse = modifyProxyResponse(w, r, sshConn)
+	// proxy.ModifyResponse = modifyProxyResponse(w, r, sshConn)
 
 	proxy.ServeHTTP(w, r)
 

--- a/pkg/webhook/conversion/user/user.go
+++ b/pkg/webhook/conversion/user/user.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"github.com/golang/glog"
 	"github.com/hobbyfarm/gargantua/pkg/webhook/conversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,8 +15,6 @@ func Init() {
 }
 
 func convert(Object *unstructured.Unstructured, toVersion string) (*unstructured.Unstructured, metav1.Status) {
-	glog.V(4).Infof("converting user crd to version " + toVersion)
-
 	convertedObject := Object.DeepCopy()
 	fromVersion := Object.GetAPIVersion()
 

--- a/pkg/webhook/conversion/user/user.go
+++ b/pkg/webhook/conversion/user/user.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func init() {
+func Init() {
 	conversion.RegisterConverter(schema.GroupKind{
 		Group: "hobbyfarm.io",
 		Kind:  "users",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Proxy to the shell server that uses the ssh connection to talk http to the virtual machine. This way Users can authenticate via gargantua and then access Webinterfaces/Services running on localhost of their Virtual Machines. Therefore keeping the Service running on the VM private if needed and still granting access to the authenticated Hobbyfarm User.

Also adds an Endpoint for the UI to recieive Information about Webinterfaces/Services that have been defined for the VM-Template

**Which issue(s) this PR fixes**:

This PR is the gargantua basis to adress the [Issue 168](https://github.com/hobbyfarm/hobbyfarm/issues/168)


