### PR TITLE
Fix VM limits

### DIFF
--- a/pkg/controllers/vmsetcontroller/vmsetcontroller.go
+++ b/pkg/controllers/vmsetcontroller/vmsetcontroller.go
@@ -289,8 +289,8 @@ func (v *VirtualMachineSetController) reconcileVirtualMachineSet(vmset *hfv1.Vir
 					Labels: map[string]string{
 						"dynamic":                          "false",
 						"vmset":                            vmset.Name,
-						"template":                         vmt.Name,
-						"environment":                      env.Name,
+						util.VirtualMachineTemplate:        vmt.Name,
+						util.EnvironmentLabel:                      env.Name,
 						"bound":                            "false",
 						"ready":                            "false",
 						util.ScheduledEventLabel: vmset.ObjectMeta.Labels[util.ScheduledEventLabel],

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -7,4 +7,5 @@ const (
 	UserLabel = 			"hobbyfarm.io/user"
 	RBACManagedLabel =		"rbac.hobbyfarm.io/managed"
 	EnvironmentLabel =		"hobbyfarm.io/environment"
+	VirtualMachineTemplate = "hobbyfarm.io/virtualmachinetemplate"
 )

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -437,8 +437,20 @@ func VirtualMachinesUsedDuringPeriod(hfClientset hfClientset.Interface, environm
 
 func CountMachinesPerTemplateAndEnvironment(vmLister hfListers.VirtualMachineLister, template string, enviroment string) (int, error) {
 	vmLabels := labels.Set{
-		"environment": enviroment,
-		"template":    template,
+		EnvironmentLabel: enviroment,
+		VirtualMachineTemplate:    template,
+	}
+
+	vms, err := vmLister.List(vmLabels.AsSelector())
+	return len(vms), err
+}
+
+func CountMachinesPerTemplateAndEnvironmentAndScheduledEvent(vmLister hfListers.VirtualMachineLister, template string, enviroment string, se string) (int, error) {
+	vmLabels := labels.Set{
+		EnvironmentLabel: enviroment,
+		VirtualMachineTemplate:    template,
+		ScheduledEventLabel: se,
+
 	}
 
 	vms, err := vmLister.List(vmLabels.AsSelector())

--- a/pkg/vmtemplateserver/vmtemplateserver.go
+++ b/pkg/vmtemplateserver/vmtemplateserver.go
@@ -289,7 +289,7 @@ func (v VirtualMachineTemplateServer) DeleteFunc(w http.ResponseWriter, r *http.
 
 	// vmt exists, now we need to check all other objects for references
 	// start with virtualmachines
-	virtualmachines, err := v.hfClientSet.HobbyfarmV1().VirtualMachines(util.GetReleaseNamespace()).List(v.ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("hobbyfarm.io/vmtemplate=%s", vmt.Name)})
+	virtualmachines, err := v.hfClientSet.HobbyfarmV1().VirtualMachines(util.GetReleaseNamespace()).List(v.ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", util.VirtualMachineTemplate, vmt.Name)})
 	if err != nil {
 		util.ReturnHTTPMessage(w, r, 500, "internalerror",
 			"error listing virtual machines while attempting vmt deletion")


### PR DESCRIPTION
**What this PR does / why we need it**:
There were some issues regarding limits.

When the current VM Count in an environment is higher is than allowed on the scheduledEvent the VMs were not created.

Count is now calculated not only for the environment but also in combination with the ScheduledEvent to fulfill its limit.
Both limits are now checked and verified.