### PR TITLE
Update go to 1.20.2, fix shell proxy for webservices

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v3
       name: go-cache
       with:
-        go-version: '1.19'
+        go-version: '1.20'
         check-latest: false
         cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##### sdk image #####
-FROM golang:1.19 AS sdk
+FROM golang:1.20.2 AS sdk
 
 WORKDIR /go/src/github.com/hobbyfarm/gargantua
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hobbyfarm/gargantua
 
-go 1.17
+go 1.20
 
 replace k8s.io/client-go => k8s.io/client-go v0.25.2
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating go to 1.20 to use more proxy features (Rewrite on httputil.ReverseProxy)

**Which issue(s) this PR fixes**:
Fixes issues with newer code-server versions. Setting the Host Header correctly
