### PR TITLE
Add service settings to rewrite path and host header

### DIFF
--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -206,7 +206,6 @@ func (sp ShellProxy) proxy(w http.ResponseWriter, r *http.Request, user v2.User)
 		} else {
 			for _, s := range servicesUnmarshaled {
 				if strconv.Itoa(s.Port) == targetPort {
-					glog.Infof("Found webservice with port %s", targetPort)
 					service = s
 					hasService = true
 					break
@@ -268,7 +267,10 @@ func (sp ShellProxy) proxy(w http.ResponseWriter, r *http.Request, user v2.User)
 	}
 
 	// dial the instance
-	sshConn, err := ssh.Dial("tcp", host+":"+port, config)
+	//sshConn, err := ssh.Dial("tcp", host+":"+port, config)
+
+
+	sshConn, err := retry(5, 1, func() (*ssh.Client, error) { return ssh.Dial("tcp", host+":"+port, config) })
 	if err != nil {
 		glog.Errorf("did not connect ssh successfully: %s", err)
 		util.ReturnHTTPMessage(w, r, 500, "error", "could not establish ssh session to vm")
@@ -645,4 +647,18 @@ func ResizePty(h int, w int) {
 	if err := sess.WindowChange(h, w); err != nil {
 		glog.Warningf("error resizing pty: %s", err)
 	}
+}
+
+func retry[T any](attempts int, sleep int, f func() (T, error)) (result T, err error) {
+    for i := 0; i < attempts; i++ {
+        if i > 0 {
+            time.Sleep(time.Duration(sleep) * time.Second)
+            sleep *= 2
+        }
+        result, err = f()
+        if err == nil {
+            return result, nil
+        }
+    }
+    return result, fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -293,7 +293,7 @@ func (sp ShellProxy) proxy(w http.ResponseWriter, r *http.Request, user v2.User)
 	// Service is configured to rewrite the rootPath (default setting).
 	// proxy path "/p/xyz/80/path" will be rewritten to application path "/path")
 	// This is needed by applications like code-server. Some applications (like jupyter when setting a base_url) need the whole proxy path
-	if hasService && !service.NoRewriteRootPath {
+	if !hasService || !service.NoRewriteRootPath {
 		r.URL.Path = mux.Vars(r)["rest"]
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows settings on services for VMTs to be used.

Services can now rewrite the Host Header optionally or disable that the path is rewritten from the proxy path `/p/xyz-id/80/path` to the application path `/path`. 
We need different behaviour patterns to fulfill more applications.

For example the code-server IDE needs Host Header rewriting but Jupyter explicity denies requests with a Host Header (that is not localhost) being set. Also code-server accepts requests to /path but Jupyter will then have a problem to resolve css and js files, therefore a base_url needs to be configured.... But then the proxy must not rewrite the base path.

Admin-UI implementation for these settings is also needed

fixes https://github.com/hobbyfarm/hobbyfarm/issues/298
