### PR TITLE
Fix bug where scenario could not be updated when using courses

### DIFF
--- a/pkg/sessionserver/sessionserver.go
+++ b/pkg/sessionserver/sessionserver.go
@@ -195,7 +195,8 @@ func (sss SessionServer) NewSessionFunc(w http.ResponseWriter, r *http.Request) 
 
 			}
 
-			encodedSS, err := json.Marshal(v.Spec)
+			preparedSession := preparedSession{v.Name, v.Spec}
+			encodedSS, err := json.Marshal(preparedSession)
 			if err != nil {
 				glog.Error(err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
When starting a scenario from the same course, gargantua did not use the PreparedSession struct, so the ID of the session was missing. This lead to an error in the UI where the scenario could not be started without reloading.

**Which issue(s) this PR fixes**:
fixes https://github.com/hobbyfarm/hobbyfarm/issues/302
