### PR TITLE
Refactor NewIndex() to ease testing

### DIFF
--- a/pkg/rbacclient/server.go
+++ b/pkg/rbacclient/server.go
@@ -6,32 +6,37 @@ import (
 )
 
 const (
-	VerbList = "list"
-	VerbGet = "get"
+	VerbList   = "list"
+	VerbGet    = "get"
 	VerbCreate = "create"
 	VerbUpdate = "update"
 	VerbDelete = "delete"
-	VerbWatch = "watch"
+	VerbWatch  = "watch"
 )
 
 type Client struct {
-	userIndex *Index
+	userIndex  *Index
 	groupIndex *Index
 }
 
 func NewRbacClient(namespace string, kubeInformerFactory informers.SharedInformerFactory) (*Client, error) {
-	userIndex, err := NewIndex("User", namespace, kubeInformerFactory)
+	rbInformer := kubeInformerFactory.Rbac().V1().RoleBindings()
+	crbInformer := kubeInformerFactory.Rbac().V1().ClusterRoleBindings()
+	rInformer := kubeInformerFactory.Rbac().V1().Roles()
+	crInformer := kubeInformerFactory.Rbac().V1().ClusterRoles()
+
+	userIndex, err := NewIndex("User", namespace, rbInformer, crbInformer, rInformer, crInformer)
 	if err != nil {
 		return nil, err
 	}
 
-	groupIndex, err := NewIndex("Group", namespace, kubeInformerFactory)
+	groupIndex, err := NewIndex("Group", namespace, rbInformer, crbInformer, rInformer, crInformer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		userIndex: userIndex,
+		userIndex:  userIndex,
 		groupIndex: groupIndex,
 	}, nil
 }
@@ -52,4 +57,3 @@ func (rs *Client) GetAccessSet(user string) (*AccessSet, error) {
 func (rs *Client) GetHobbyfarmRoleBindings(user string) ([]*rbacv1.RoleBinding, error) {
 	return rs.userIndex.getRoleBindings(user)
 }
-


### PR DESCRIPTION
Currently the NewIndex builder takes a sharedInformerFactory as an argument. This makes it difficult to test as you cannot easily fake and inject specific informers which you may need to attach handlers to, etc. 

This PR adjusts the rbac index builder to take typed informer interfaces to ease unit testing. 