### PR TITLE
Unit testing for RBAC client

### DIFF
--- a/pkg/rbacclient/access_test.go
+++ b/pkg/rbacclient/access_test.go
@@ -1,0 +1,37 @@
+package rbacclient
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_Grants(t *testing.T) {
+	accessSet := AccessSet{
+		Subject: "fake@fake.com",
+		Access: map[string]bool{
+			"/hobbyfarm.io/scheduledevents/list": true,
+			"/hobbyfarm.io/scenarios/list":       true,
+		},
+	}
+
+	sePerms := RbacRequest().HobbyfarmPermission("scheduledevents", "list").GetPermissions()
+	sPerms := RbacRequest().HobbyfarmPermission("scenarios", "list").GetPermissions()
+
+	nPerms := RbacRequest().HobbyfarmPermission("courses", "list").GetPermissions()
+
+	for _, p := range append(sePerms, sPerms...) {
+		t.Run(fmt.Sprintf("should allow %s/%s/%s", p.GetAPIGroup(), p.GetResource(), p.GetVerb()), func(t *testing.T) {
+			if !accessSet.Grants(p) {
+				t.Error("accessset should have granted, did not")
+			}
+		})
+	}
+
+	for _, p := range nPerms {
+		t.Run(fmt.Sprintf("should not allow %s/%s/%s", p.GetAPIGroup(), p.GetResource(), p.GetVerb()), func(t *testing.T) {
+			if accessSet.Grants(p) {
+				t.Error("accessset granted, should not have")
+			}
+		})
+	}
+}

--- a/pkg/rbacclient/index.go
+++ b/pkg/rbacclient/index.go
@@ -3,7 +3,6 @@ package rbacclient
 import (
 	"fmt"
 	v1 "k8s.io/api/rbac/v1"
-	v12 "k8s.io/client-go/informers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -35,10 +34,13 @@ type Index struct {
 func NewIndex(
 	kind string,
 	namespace string,
-	rbInformer v12.RoleBindingInformer,
-	crbInformer v12.ClusterRoleBindingInformer,
-	rInformer v12.RoleInformer,
-	crInformer v12.ClusterRoleInformer) (*Index, error) {
+	//	rbInformer v12.RoleBindingInformer,
+	roleBindingInformer cache.SharedIndexInformer,
+	// crbInformer v12.ClusterRoleBindingInformer,
+	clusterRoleBindingInformer cache.SharedIndexInformer,
+	// rInformer v12.RoleInformer,
+	roleInformer cache.SharedIndexInformer,
+	clusterRoleInformer cache.SharedIndexInformer) (*Index, error) {
 	i := &Index{
 		kind:      kind,
 		namespace: namespace,
@@ -49,20 +51,20 @@ func NewIndex(
 	crbIndexers := map[string]cache.IndexFunc{rbIndex + "-" + kind: i.clusterRoleBindingSubjectIndexer}
 
 	// ... then tell the informers to use those indexers
-	if err := rbInformer.Informer().AddIndexers(rbIndexers); err != nil {
+	if err := roleBindingInformer.AddIndexers(rbIndexers); err != nil {
 		return nil, err
 	}
 
-	if err := crbInformer.Informer().AddIndexers(crbIndexers); err != nil {
+	if err := clusterRoleBindingInformer.AddIndexers(crbIndexers); err != nil {
 		return nil, err
 	}
 
 	// finally, generate the indexers and store in the index struct
-	i.roleBindingIndexer = rbInformer.Informer().GetIndexer()
-	i.clusterRoleBindingIndexer = crbInformer.Informer().GetIndexer()
+	i.roleBindingIndexer = roleBindingInformer.GetIndexer()
+	i.clusterRoleBindingIndexer = clusterRoleBindingInformer.GetIndexer()
 
-	i.roleIndexer = rInformer.Informer().GetIndexer()
-	i.clusterRoleIndexer = crInformer.Informer().GetIndexer()
+	i.roleIndexer = roleInformer.GetIndexer()
+	i.clusterRoleIndexer = clusterRoleInformer.GetIndexer()
 
 	return i, nil
 }

--- a/pkg/rbacclient/index_test.go
+++ b/pkg/rbacclient/index_test.go
@@ -1,0 +1,133 @@
+package rbacclient
+
+import (
+	"context"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"time"
+)
+
+var (
+	fakeEmail           = "fake@fake.com"
+	fakeRoleName        = "fake-role"
+	fakeRoleBindingName = "fake-rolebinding"
+	fakeNamespace       = "fake"
+
+	roleAPIGroups = []string{"hobbyfarm.io"}
+	roleResources = []string{"scheduledevents"}
+	roleVerbs     = []string{"list"}
+
+	userKind  = "User"
+	groupKind = "Group"
+	roleKind  = "Role"
+)
+
+func createIndex(client kubernetes.Interface, kind string) (*Index, error) {
+	sif := informers.NewSharedInformerFactory(client, time.Second*10)
+
+	return NewIndex(kind, fakeNamespace, sif)
+}
+
+func setupRole(client kubernetes.Interface) error {
+	// add a role
+	role := v1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fakeRoleName,
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: roleAPIGroups,
+				Resources: roleResources,
+				Verbs:     roleVerbs,
+			},
+		},
+	}
+
+	_, err := client.RbacV1().Roles(fakeNamespace).Create(context.TODO(), &role, metav1.CreateOptions{})
+	return err
+}
+
+func setupRoleBinding(client kubernetes.Interface) error {
+	roleBinding := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fakeRoleBindingName,
+		},
+		Subjects: []v1.Subject{
+			{
+				Kind:      userKind,
+				APIGroup:  RbacGroup,
+				Name:      fakeEmail,
+				Namespace: fakeNamespace,
+			},
+		},
+		RoleRef: v1.RoleRef{
+			APIGroup: RbacGroup,
+			Kind:     roleKind,
+			Name:     fakeRoleName,
+		},
+	}
+
+	_, err := client.RbacV1().RoleBindings(fakeNamespace).Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	return err
+}
+
+func Test_CreateRoleAndBinding(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	if err := setupRole(client); err != nil {
+		t.Error(err)
+	}
+
+	if err := setupRoleBinding(client); err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_CreateIndex(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	_, err := createIndex(client, userKind)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_UserAccessSet(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	userIndex, err := createIndex(client, userKind)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := setupRole(client); err != nil {
+		t.Error(err)
+	}
+
+	if err := setupRoleBinding(client); err != nil {
+		t.Error(err)
+	}
+
+	accessSet, err := userIndex.GetAccessSet(fakeEmail)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Run("subject matches", func(t *testing.T) {
+		if accessSet.Subject != fakeEmail {
+			t.Errorf("access set subject %s did not match email %s", accessSet.Subject, fakeEmail)
+		}
+	})
+
+	t.Run("access set not nil", func(t *testing.T) {
+		if accessSet.Access != nil {
+			t.Error("access set nil")
+		}
+	})
+
+}

--- a/pkg/rbacclient/rbacclient_test.go
+++ b/pkg/rbacclient/rbacclient_test.go
@@ -1,0 +1,117 @@
+package rbacclient
+
+import (
+	"context"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	FakeEmail = "fake@fake.com"
+
+	FakeRoleName               = "fake-role"
+	FakeClusterRoleName        = "fake-clusterrole"
+	FakeRoleBindingName        = "fake-rolebinding"
+	FakeClusterRoleBindingName = "fake-clusterrolebinding"
+	FakeNamespace              = "fake"
+
+	RoleAPIGroup        = "hobbyfarm.io"
+	RoleResource        = "scheduledevents"
+	ClusterRoleResource = "scenarios"
+	RoleVerb            = "list"
+	ClusterRoleVerb     = "get"
+
+	NotAllowedResource = "courses"
+	NotAllowedVerb     = "update"
+
+	UserKind        = "User"
+	GroupKind       = "Group"
+	RoleKind        = "Role"
+	ClusterRoleKind = "ClusterRole"
+)
+
+func SetupRole(client kubernetes.Interface) error {
+	// add a role
+	role := v1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: FakeRoleName,
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{RoleAPIGroup},
+				Resources: []string{RoleResource},
+				Verbs:     []string{RoleVerb},
+			},
+		},
+	}
+
+	_, err := client.RbacV1().Roles(FakeNamespace).Create(context.TODO(), &role, metav1.CreateOptions{})
+	return err
+}
+
+func SetupClusterRole(client kubernetes.Interface) error {
+	clusterRole := v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: FakeClusterRoleName,
+		},
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{RoleAPIGroup},
+				Resources: []string{ClusterRoleResource},
+				Verbs:     []string{ClusterRoleVerb},
+			},
+		},
+	}
+
+	_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), &clusterRole, metav1.CreateOptions{})
+	return err
+}
+
+func SetupRoleBinding(client kubernetes.Interface) error {
+	roleBinding := v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: FakeRoleBindingName,
+		},
+		Subjects: []v1.Subject{
+			{
+				Kind:      UserKind,
+				APIGroup:  RbacGroup,
+				Name:      FakeEmail,
+				Namespace: FakeNamespace,
+			},
+		},
+		RoleRef: v1.RoleRef{
+			APIGroup: RbacGroup,
+			Kind:     RoleKind,
+			Name:     FakeRoleName,
+		},
+	}
+
+	_, err := client.RbacV1().RoleBindings(FakeNamespace).Create(context.TODO(), &roleBinding, metav1.CreateOptions{})
+	return err
+}
+
+func SetupClusterRoleBinding(client kubernetes.Interface) error {
+	clusterRolebinding := v1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: FakeClusterRoleBindingName,
+		},
+		Subjects: []v1.Subject{
+			{
+				Kind:      UserKind,
+				APIGroup:  RbacGroup,
+				Name:      FakeEmail,
+				Namespace: FakeNamespace,
+			},
+		},
+		RoleRef: v1.RoleRef{
+			APIGroup: RbacGroup,
+			Kind:     ClusterRoleKind,
+			Name:     FakeClusterRoleName,
+		},
+	}
+
+	_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), &clusterRolebinding, metav1.CreateOptions{})
+	return err
+}

--- a/pkg/rbacclient/server.go
+++ b/pkg/rbacclient/server.go
@@ -20,10 +20,10 @@ type Client struct {
 }
 
 func NewRbacClient(namespace string, kubeInformerFactory informers.SharedInformerFactory) (*Client, error) {
-	rbInformer := kubeInformerFactory.Rbac().V1().RoleBindings()
-	crbInformer := kubeInformerFactory.Rbac().V1().ClusterRoleBindings()
-	rInformer := kubeInformerFactory.Rbac().V1().Roles()
-	crInformer := kubeInformerFactory.Rbac().V1().ClusterRoles()
+	rbInformer := kubeInformerFactory.Rbac().V1().RoleBindings().Informer()
+	crbInformer := kubeInformerFactory.Rbac().V1().ClusterRoleBindings().Informer()
+	rInformer := kubeInformerFactory.Rbac().V1().Roles().Informer()
+	crInformer := kubeInformerFactory.Rbac().V1().ClusterRoles().Informer()
 
 	userIndex, err := NewIndex("User", namespace, rbInformer, crbInformer, rInformer, crInformer)
 	if err != nil {

--- a/pkg/rbacclient/server.go
+++ b/pkg/rbacclient/server.go
@@ -6,32 +6,37 @@ import (
 )
 
 const (
-	VerbList = "list"
-	VerbGet = "get"
+	VerbList   = "list"
+	VerbGet    = "get"
 	VerbCreate = "create"
 	VerbUpdate = "update"
 	VerbDelete = "delete"
-	VerbWatch = "watch"
+	VerbWatch  = "watch"
 )
 
 type Client struct {
-	userIndex *Index
+	userIndex  *Index
 	groupIndex *Index
 }
 
 func NewRbacClient(namespace string, kubeInformerFactory informers.SharedInformerFactory) (*Client, error) {
-	userIndex, err := NewIndex("User", namespace, kubeInformerFactory)
+	rbInformer := kubeInformerFactory.Rbac().V1().RoleBindings()
+	crbInformer := kubeInformerFactory.Rbac().V1().ClusterRoleBindings()
+	rInformer := kubeInformerFactory.Rbac().V1().Roles()
+	crInformer := kubeInformerFactory.Rbac().V1().ClusterRoles()
+
+	userIndex, err := NewIndex("User", namespace, rbInformer, crbInformer, rInformer, crInformer)
 	if err != nil {
 		return nil, err
 	}
 
-	groupIndex, err := NewIndex("Group", namespace, kubeInformerFactory)
+	groupIndex, err := NewIndex("Group", namespace, rbInformer, crbInformer, rInformer, crInformer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		userIndex: userIndex,
+		userIndex:  userIndex,
 		groupIndex: groupIndex,
 	}, nil
 }
@@ -52,4 +57,3 @@ func (rs *Client) GetAccessSet(user string) (*AccessSet, error) {
 func (rs *Client) GetHobbyfarmRoleBindings(user string) ([]*rbacv1.RoleBinding, error) {
 	return rs.userIndex.getRoleBindings(user)
 }
-

--- a/pkg/rbacclient/server_test.go
+++ b/pkg/rbacclient/server_test.go
@@ -1,0 +1,97 @@
+package rbacclient
+
+import (
+	"context"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+func Test_RbacClient(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	for _, f := range []func(p kubernetes.Interface) error{
+		SetupRole,
+		SetupClusterRole,
+		SetupRoleBinding,
+		SetupClusterRoleBinding,
+	} {
+		if err := f(client); err != nil {
+			t.Errorf("error calling setup func: %s", err.Error())
+		}
+	}
+
+	sif := informers.NewSharedInformerFactory(client, 0)
+
+	rbacclient, err := NewRbacClient(FakeNamespace, sif)
+	if err != nil {
+		t.Errorf("error setting up RbacClient: %s", err.Error())
+	}
+
+	sif.Start(context.TODO().Done())
+
+	sif.WaitForCacheSync(context.TODO().Done())
+
+	t.Run("test get accessset", func(t *testing.T) {
+		as, err := rbacclient.GetAccessSet(FakeEmail)
+		if err != nil {
+			t.Errorf("error getting access set: %s", err.Error())
+		}
+
+		if len(as.Access) == 0 {
+			t.Error("empty access set")
+		}
+	})
+
+	t.Run("test role permissions allowed", func(t *testing.T) {
+		perms := RbacRequest().HobbyfarmPermission(RoleResource, RoleVerb).GetPermissions()
+
+		for _, p := range perms {
+			allowed, err := rbacclient.Grants(FakeEmail, p)
+			if err != nil {
+				t.Errorf("error while calling rbacclient.Grants: %s", err.Error())
+				return
+			}
+
+			if !allowed {
+				t.Errorf("rbac permission %s/%s/%s not granted, should be",
+					RoleAPIGroup, RoleResource, RoleVerb)
+			}
+		}
+	})
+
+	t.Run("test clusterrole permissions allowed", func(t *testing.T) {
+		perms := RbacRequest().HobbyfarmPermission(ClusterRoleResource, ClusterRoleVerb).GetPermissions()
+
+		for _, p := range perms {
+			allowed, err := rbacclient.Grants(FakeEmail, p)
+			if err != nil {
+				t.Errorf("error while calling rbacclient.Grants: %s", err.Error())
+				return
+			}
+
+			if !allowed {
+				t.Errorf("rbac permission %s/%s/%s not granted, should be",
+					RoleAPIGroup, ClusterRoleResource, ClusterRoleVerb)
+			}
+		}
+	})
+
+	t.Run("test courses not allowed", func(t *testing.T) {
+		perms := RbacRequest().HobbyfarmPermission(NotAllowedResource, NotAllowedVerb).GetPermissions()
+
+		for _, p := range perms {
+			allowed, err := rbacclient.Grants(FakeEmail, p)
+			if err != nil {
+				t.Errorf("error while calling rbacclient.grants: %s", err.Error())
+				return
+			}
+
+			if allowed {
+				t.Errorf("rbac permission %s/%s/%s allowed, should NOT be",
+					RoleAPIGroup, NotAllowedResource, NotAllowedVerb)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR adds initial unit tests for the rbacclient portion of Gargantua. 

This is necessary as soon work will begin to add functionality to this area, and we'd like to not disturb anything :)

Mostly these tests verify that an rbac client can be created, that roles, bindings, and their cluster equivalents can be created and cached. 
The tests also ensure at a basic level that RBAC decisions are made correctly (e.g. allowed vs disallowed). 

This can probably be enhanced in many ways but it serves as a decent start.
