### PR TITLE
Removes executor from gargantua

### DIFF
--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,3 +1,0 @@
-FROM rancher/terraform-controller-executor:latest
-
-COPY terraform-provider-ranchervm /usr/bin/terraform-provider-ranchervm


### PR DESCRIPTION
The executor/ directory contained the ranchervm terraform provider as well as a Dockerfile to build an executor with that provider. 
This was an extra 70-some megabytes that we did not need in Gargantua.
I have moved this to https://github.com/hobbyfarm/terraform-provider-ranchervm and deleted those files here.
