### PR TITLE
Install Scope CRD in Settingservice

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -113,11 +113,6 @@ func GenerateCRDs() []crder.CRD {
 				IsNamespaced(true).
 				AddVersion("v1", &v1.DynamicBindConfiguration{}, nil)
 		}),
-		hobbyfarmCRD(&v1.Scope{}, func(c *crder.CRD) {
-			c.IsNamespaced(true).AddVersion("v1", &v1.Scope{}, func(cv *crder.Version) {
-				cv.WithColumn("DisplayName", ".displayName").IsServed(true).IsStored(true)
-			})
-		}),
 		terraformCRD(&terraformv1.Module{}, func(c *crder.CRD) {
 			c.
 				IsNamespaced(true).

--- a/services/settingsvc/internal/crd.go
+++ b/services/settingsvc/internal/crd.go
@@ -18,6 +18,11 @@ const (
 
 func GenerateSettingCRD(caBundle string, reference crd.ServiceReference) []crder.CRD {
 	return []crder.CRD{
+		hobbyfarmCRD(&v1.Scope{}, func(c *crder.CRD) {
+			c.IsNamespaced(true).AddVersion("v1", &v1.Scope{}, func(cv *crder.Version) {
+				cv.WithColumn("DisplayName", ".displayName").IsServed(true).IsStored(true)
+			})
+		}),
 		hobbyfarmCRD(&v1.Setting{}, func(c *crder.CRD) {
 			c.IsNamespaced(true).AddVersion("v1", &v1.Setting{}, func(cv *crder.Version) {
 				cv.


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves Scope CRD to be installed by settingservice instead of gargantua

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/401

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
