### PR TITLE
Added missing waitgroup add

### DIFF
--- a/v3/services/authnsvc/main.go
+++ b/v3/services/authnsvc/main.go
@@ -46,13 +46,14 @@ func main() {
 	authn.RegisterAuthNServer(gs, as)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		microservices.StartGRPCServer(gs, serviceConfig.EnableReflection)
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		authServer, err := authnservice.NewAuthServer(accesscodeClient, userClient, settingClient, rbacClient, as)

--- a/v3/services/rbacsvc/main.go
+++ b/v3/services/rbacsvc/main.go
@@ -69,13 +69,14 @@ func main() {
 	authrClient := authr.NewAuthRClient(connections[microservices.AuthR])
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		microservices.StartGRPCServer(gs, serviceConfig.EnableReflection)
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		rbacServer := rbacservice.NewRbacServer(rs, authnClient, authrClient)

--- a/v3/services/settingsvc/main.go
+++ b/v3/services/settingsvc/main.go
@@ -77,13 +77,14 @@ func main() {
 	settingservice.Preinstall(ctx, ss)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		microservices.StartGRPCServer(gs, serviceConfig.EnableReflection)
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		settingServer, err := settingservice.NewSettingServer(authnClient, authrClient, ss)

--- a/v3/services/usersvc/main.go
+++ b/v3/services/usersvc/main.go
@@ -78,13 +78,14 @@ func main() {
 	user.RegisterUserSvcServer(gs, us)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		microservices.StartGRPCServer(gs, serviceConfig.EnableReflection)
 	}()
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 


### PR DESCRIPTION
A few microservices only had a single call to wg.Add(), but there were two wg.Done() inside goroutines. 

This PR adds those wg.Add(1) calls for the second goroutines. 
