### PR TITLE
Remove generics from property slice/map validation, add tests

### DIFF
--- a/v3/pkg/property/validation_test.go
+++ b/v3/pkg/property/validation_test.go
@@ -1,0 +1,78 @@
+package property
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	testValues = map[bool]map[ValueType]map[DataType]string{
+		true: {
+			ValueTypeArray: {
+				DataTypeBoolean: "[true, false]",
+				DataTypeInteger: "[1,2,3,4]",
+				DataTypeFloat:   "[1.234, 1.432]",
+				DataTypeString:  "[\"one\", \"two\"]",
+			},
+			ValueTypeMap: {
+				DataTypeBoolean: "{\"one\": true, \"two\": false}",
+				DataTypeInteger: "{\"one\": 1, \"two\": 2}",
+				DataTypeFloat:   "{\"one\": 1.234, \"two\": 1.432}",
+				DataTypeString:  "{\"one\": \"one\", \"two\": \"two\"}",
+			},
+		},
+		false: {
+			ValueTypeArray: {
+				DataTypeBoolean: "[true, true]",
+				DataTypeInteger: "[1, 1, 1]",
+				DataTypeFloat:   "[1.234, 1.234]",
+				DataTypeString:  "[\"one\", \"one\"]",
+			},
+			ValueTypeMap: {
+				DataTypeBoolean: "{\"one\": true, \"two\": true}",
+				DataTypeInteger: "{\"one\": 1, \"two\": 1}",
+				DataTypeFloat:   "{\"one\": 1.234, \"two\": 1.234}",
+				DataTypeString:  "{\"one\": \"one\", \"two\": \"one\"}",
+			},
+		},
+	}
+)
+
+func TestValidate_UniqueSlices(t *testing.T) {
+	for unique, valueTypes := range testValues {
+		for valueType, dataTypes := range valueTypes {
+			for dataType, testString := range dataTypes {
+				var name = fmt.Sprintf("%s of %s", valueType, dataType)
+				if unique {
+					name = "unique " + name + " should pass validation"
+				} else {
+					name = "non-unique " + name + " should not pass validation"
+				}
+
+				t.Run(name, func(t *testing.T) {
+					var p = Property{
+						DataType:  dataType,
+						ValueType: valueType,
+						SettingValidation: SettingValidation{
+							UniqueItems: true,
+						},
+					}
+
+					err := p.Validate(testString)
+
+					// unique and no error is good
+					// unique and error is bad
+					if err != nil && unique {
+						t.Error(err)
+					}
+
+					// not unique and error is good
+					// not unique and no error is bad
+					if err == nil && !unique {
+						t.Error(err)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
k8s.io/kube-openapi/cmd/openapi-gen is not able to generate openapi types for code that uses generics.
This is supposedly going to change soon but not on a timeline that works for us.

I have gone through property and removed use of generics for validation of unique in maps and slices. I have replaced this
with some light crimes (using reflection). 

I added tests to confirm pre- and post-change success.
