### PR TITLE
Use id instead of name, add id of vmset to updateVMSetCount function

### DIFF
--- a/v3/services/scheduledeventsvc/internal/controller.go
+++ b/v3/services/scheduledeventsvc/internal/controller.go
@@ -257,7 +257,7 @@ func (sc *ScheduledEventController) provisionScheduledEvent(se *scheduledeventpb
 
 					if err != nil || len(existingVMSetsList.GetVmsets()) == 0 { // create new vmset if no existing one was found
 						vmsRand := fmt.Sprintf("%s-%08x", baseNameScheduledPrefix, rand.Uint32())
-						vmsId := strings.Join([]string{"se", se.Name, "vms", vmsRand}, "-")
+						vmsId := strings.Join([]string{"se", se.Id, "vms", vmsRand}, "-")
 						vmSets = append(vmSets, vmsId)
 						_, err = sc.vmSetClient.CreateVMSet(sc.Context, &vmsetpb.CreateVMSetRequest{
 							Id:                  vmsId,

--- a/v3/services/vmsetsvc/internal/controller.go
+++ b/v3/services/vmsetsvc/internal/controller.go
@@ -272,6 +272,7 @@ func (v *VMSetController) reconcileVirtualMachineSet(vmset *vmsetpb.VMSet) error
 
 func (v *VMSetController) updateVMSetCount(vmSetName string, active int, prov int) error {
 	_, err := v.internalVmSetServer.UpdateVMSetStatus(v.Context, &vmsetpb.UpdateVMSetStatusRequest{
+		Id:          vmSetName,
 		Available:   wrapperspb.UInt32(uint32(active)),
 		Provisioned: wrapperspb.UInt32(uint32(prov)),
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
`scheduledeventsvc/controller:260.`
se.name used instead of se.id resulting in this error when spaces or other special chars were used inside the name of the scheduled event

add missing id to the VMSet in UpdateVMSetStatus in `vmsetservice/controller.go:273: updateVMSetCount()`

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/439

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
