### PR TITLE
Fix issue where only one rule is being displayed

### DIFF
--- a/v3/services/rbacsvc/internal/roles.go
+++ b/v3/services/rbacsvc/internal/roles.go
@@ -220,7 +220,7 @@ func (s Server) prepareRole(role *rbacpb.Role) (preparedRole PreparedRole) {
 	}
 
 	for _, r := range role.GetRules() {
-		pr.Rules = append(preparedRole.Rules, PreparedRule{
+		pr.Rules = append(pr.Rules, PreparedRule{
 			Resources: r.GetResources(),
 			Verbs:     r.GetVerbs(),
 			APIGroups: r.GetApiGroups(),


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an error were rules were appended to the wrong list leading to only the last rule being displayed

**Which issue(s) this PR fixes**:
fixes https://github.com/hobbyfarm/hobbyfarm/issues/442

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
