### PR TITLE
Fix vm template client connection

### DIFF
--- a/v3/services/vmsvc/main.go
+++ b/v3/services/vmsvc/main.go
@@ -38,6 +38,7 @@ func main() {
 	services := []microservices.MicroService{
 		microservices.AuthN,
 		microservices.AuthR,
+		microservices.VMTemplate,
 	}
 	connections := microservices.EstablishConnections(services, serviceConfig.ClientCert)
 	for _, conn := range connections {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes nil pointer exception while using the vm template client inside the vm service.
