### PR TITLE
Replace shell endpoint in cloud config

### DIFF
--- a/v3/services/terraformsvc/internal/controller.go
+++ b/v3/services/terraformsvc/internal/controller.go
@@ -268,6 +268,13 @@ func (v *VMController) handleProvision(vm *vmpb.VM) (error, bool) {
 			password = ""
 		}
 
+		shellEndpoint := vm.GetStatus().WsEndpoint
+
+		_, exists = config["cloud-config"]
+		if exists {
+			config["cloud-config"] = strings.Replace(config["cloud-config"], "$_SHELL_ENDPOINT_$", shellEndpoint, -1)
+		}
+
 		vmOwnerReference := []metav1.OwnerReference{
 			{
 				APIVersion: "hobbyfarm.io/v1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces `$_SHELL_ENDPOINT_$` inside any Cloud Init configuration

**Which issue(s) this PR fixes**:
We have a complex cloud init configuration for kibana. We need to set some kibana Configurations to the endpoint of the shell in order to get kibana to work with our shell webservice proxy.

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
