### PR TITLE
Fix 478: Copy Scenario into new structure

### DIFF
--- a/v3/services/scenariosvc/internal/grpc.go
+++ b/v3/services/scenariosvc/internal/grpc.go
@@ -389,14 +389,23 @@ func (s *GrpcScenarioServer) CopyScenario(ctx context.Context, req *generalpb.Re
 			id,
 		)
 	}
+
 	copyName := string(name) + " - Copy"
 	copyName = base64.StdEncoding.EncodeToString([]byte(copyName))
 	copyId := util.GenerateResourceName("s", copyName, 10)
 
-	scenario.Name = copyId
-	scenario.Spec.Name = copyName
+	copyScenario := &hfv1.Scenario{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        copyId,
+			Labels:      scenario.Labels,
+			Annotations: scenario.Annotations,
+		},
+		Spec: scenario.Spec,
+	}
 
-	_, err = s.scenarioClient.Create(ctx, scenario, metav1.CreateOptions{})
+	copyScenario.Spec.Name = copyName
+
+	_, err = s.scenarioClient.Create(ctx, copyScenario, metav1.CreateOptions{})
 	if err != nil {
 		glog.Errorf("Error attempting to create a copy of scenario %s: %v", id, err)
 		return &emptypb.Empty{}, hferrors.GrpcError(


### PR DESCRIPTION
**What this PR does / why we need it**:
Create new scenario obj to avoid error with ressourceVersion field being set

**Which issue(s) this PR fixes**:
fixes https://github.com/hobbyfarm/hobbyfarm/issues/478

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
