### PR TITLE
Added backend logic to remove multiple access codes in one request

### DIFF
--- a/v3/pkg/util/util.go
+++ b/v3/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	mrand "math/rand"
+	"slices"
 
 	hfv1 "github.com/hobbyfarm/gargantua/v3/pkg/apis/hobbyfarm.io/v1"
 	hfClientset "github.com/hobbyfarm/gargantua/v3/pkg/client/clientset/versioned"
@@ -575,4 +576,16 @@ func AppendDynamicScenariosByCategories(
 
 	scenariosList = UniqueStringSlice(scenariosList)
 	return scenariosList
+}
+
+// This function returns a slice of all strings from the target slice, which are not also found in the input slice
+func GetUniqueStringsFromSlice(targetSlice []string, inputSlice []string) []string {
+	unique := make([]string, 0)
+	for _, v := range targetSlice {
+		idx := slices.IndexFunc(inputSlice, func(s string) bool { return s == v })
+		if idx == -1 {
+			unique = append(unique, v)
+		}
+	}
+	return unique
 }

--- a/v3/services/authnsvc/internal/authnservice.go
+++ b/v3/services/authnsvc/internal/authnservice.go
@@ -214,7 +214,7 @@ func (a AuthServer) RemoveAccessCodeFunc(w http.ResponseWriter, r *http.Request)
 
 	accessCode := strings.ToLower(vars["access_code"])
 
-	err = a.RemoveAccessCode(user, accessCode, r.Context())
+	err = a.RemoveAccessCodes(user, []string{accessCode}, r.Context())
 
 	if err != nil {
 		glog.Error(err)
@@ -225,6 +225,37 @@ func (a AuthServer) RemoveAccessCodeFunc(w http.ResponseWriter, r *http.Request)
 	util.ReturnHTTPMessage(w, r, 200, "success", accessCode)
 
 	glog.V(2).Infof("removed accesscode %s to user %s", accessCode, user.Email)
+}
+
+func (a AuthServer) RemoveMultipleAccessCodesFunc(w http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("Authorization")
+	user, err := a.internalAuthnServer.AuthN(r.Context(), &authnpb.AuthNRequest{
+		Token: token,
+	})
+	if err != nil {
+		util.ReturnHTTPMessage(w, r, 403, "forbidden", "no access to get accesscode")
+		return
+	}
+
+	var acUnmarshaled []string
+	err = json.NewDecoder(r.Body).Decode(&acUnmarshaled)
+	if err != nil {
+		glog.Errorf("error while unmarshaling accesscodes %v", err)
+		util.ReturnHTTPMessage(w, r, 500, "error", "error attempting to update")
+		return
+	}
+
+	err = a.RemoveAccessCodes(user, acUnmarshaled, r.Context())
+
+	if err != nil {
+		glog.Error(err)
+		util.ReturnHTTPMessage(w, r, 500, "error", "error removing access code")
+		return
+	}
+
+	util.ReturnHTTPMessage(w, r, 200, "success", "access codes have been deleted")
+
+	glog.V(2).Infof("removed accesscodes %v to user %s", acUnmarshaled, user.Email)
 }
 
 func (a AuthServer) AddAccessCode(user *userpb.User, accessCode string, ctx context.Context) error {
@@ -282,33 +313,25 @@ func (a AuthServer) AddAccessCode(user *userpb.User, accessCode string, ctx cont
 	return nil
 }
 
-func (a AuthServer) RemoveAccessCode(user *userpb.User, accessCode string, ctx context.Context) error {
-	if len(user.GetId()) == 0 || len(accessCode) == 0 {
-		return fmt.Errorf("bad parameters passed, %s:%s", user.GetId(), accessCode)
+func (a AuthServer) RemoveAccessCodes(user *userpb.User, accessCodes []string, ctx context.Context) error {
+	if len(user.GetId()) == 0 || len(accessCodes) == 0 || len(accessCodes[0]) == 0 {
+		return fmt.Errorf("bad parameters passed, %s:%s", user.GetId(), accessCodes)
 	}
-
-	accessCode = strings.ToLower(accessCode)
-
-	var newAccessCodes []string
-
-	newAccessCodes = make([]string, 0)
 
 	if len(user.AccessCodes) == 0 {
 		// there were no access codes at this point so what are we doing
-		return fmt.Errorf("accesscode %s for user %s was not found", accessCode, user.GetId())
-	} else {
-		found := false
-		for _, ac := range user.AccessCodes {
-			if ac == accessCode {
-				found = true
-			} else {
-				newAccessCodes = append(newAccessCodes, ac)
-			}
-		}
-		if !found {
-			// the access code wasn't found so no update required
-			return nil
-		}
+		return fmt.Errorf("user %s has no accesscodes", user.GetId())
+	}
+
+	for index, inputAccessCode := range accessCodes {
+		accessCodes[index] = strings.ToLower(inputAccessCode)
+	}
+
+	newAccessCodes := util.GetUniqueStringsFromSlice(user.AccessCodes, accessCodes)
+
+	// No codes have been changed, return before performing updates
+	if len(user.AccessCodes) == len(newAccessCodes) {
+		return nil
 	}
 
 	// Important: user.GetPassword() contains the hashed password. Hence, it can and should not be updated!

--- a/v3/services/authnsvc/internal/server.go
+++ b/v3/services/authnsvc/internal/server.go
@@ -42,6 +42,7 @@ func (a AuthServer) SetupRoutes(r *mux.Router) {
 	r.HandleFunc("/auth/accesscode", a.ListAccessCodeFunc).Methods("GET")
 	r.HandleFunc("/auth/accesscode", a.AddAccessCodeFunc).Methods("POST")
 	r.HandleFunc("/auth/accesscode/{access_code}", a.RemoveAccessCodeFunc).Methods("DELETE")
+	r.HandleFunc("/auth/accesscodes", a.RemoveMultipleAccessCodesFunc).Methods("DELETE")
 	r.HandleFunc("/auth/changepassword", a.ChangePasswordFunc).Methods("POST")
 	r.HandleFunc("/auth/settings", a.RetreiveSettingsFunc).Methods("GET")
 	r.HandleFunc("/auth/settings", a.UpdateSettingsFunc).Methods("POST")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds replaces the single accesscode deletion with a new endpoint capable of deleting multiple accesscodes at once.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/hobbyfarm/hobbyfarm/issues/391

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
