### PR TITLE
Fix VM Execution Comparison

### DIFF
--- a/v3/services/terraformsvc/internal/controller.go
+++ b/v3/services/terraformsvc/internal/controller.go
@@ -395,17 +395,17 @@ func (v *VMController) handleProvision(vm *vmpb.VM) (error, bool) {
 
 		tfExecs := tfExecsList.GetExecutions()
 
-		var newestTimestamp int32
+		var newestTimestamp time.Time
 		var tfExec *terraformpb.Execution
 		if len(tfExecs) == 0 {
 			return fmt.Errorf("no executions found for terraform state"), true
 		}
 
-		newestTimestamp = tfExecs[0].GetCreationTimestamp().GetNanos()
+		newestTimestamp = tfExecs[0].GetCreationTimestamp().AsTime()
 		tfExec = tfExecs[0]
 		for _, e := range tfExecs {
-			if newestTimestamp < e.GetCreationTimestamp().GetNanos() {
-				newestTimestamp = e.GetCreationTimestamp().GetNanos()
+			if newestTimestamp.Before(e.GetCreationTimestamp().AsTime()) {
+				newestTimestamp = e.GetCreationTimestamp().AsTime()
 				tfExec = e
 			}
 		}

--- a/v3/services/terraformsvc/internal/controller.go
+++ b/v3/services/terraformsvc/internal/controller.go
@@ -370,16 +370,6 @@ func (v *VMController) handleProvision(vm *vmpb.VM) (error, bool) {
 		return nil, false
 
 	} else if vm.Status.Status == string(hfv1.VmStatusProvisioned) {
-		// let's check the status of our tf provision
-		/*tfState, err := t.tfsLister.States(util.GetReleaseNamespace()).Get(vm.Status.TFState)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("execution not found")
-			}
-			return nil
-		} */
-		// TEMPORARY WORKAROUND UNTIL WE FIGURE OUT A BETTER WAY TO DO THIS
-
 		if vm.GetStatus().GetTfstate() == "" {
 			return fmt.Errorf("tf state was blank in object"), true
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Comparison of executions in terraform controller failed due to ToNanos() being used which only returns the difference in nanoseconds from the last second. This lead to the check failing in a random number of times

**Which issue(s) this PR fixes**:

<!-- 
Automatically closes issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
